### PR TITLE
Changed the informal "thru" for its regular form.

### DIFF
--- a/excel/resources/table.md
+++ b/excel/resources/table.md
@@ -12,7 +12,7 @@ Represents an Excel table.
 |name|string|Name of the table.|
 |showHeaders|bool|Indicates whether the header row is visible or not. This value can be set to show or remove the header row.|
 |showTotals|bool|Indicates whether the total row is visible or not. This value can be set to show or remove the total row.|
-|style|string|Constant value that represents the Table style. Possible values are: TableStyleLight1 thru TableStyleLight21, TableStyleMedium1 thru TableStyleMedium28, TableStyleStyleDark1 thru TableStyleStyleDark11. A custom user-defined style present in the workbook can also be specified.|
+|style|string|Constant value that represents the Table style. Possible values are: TableStyleLight1 through TableStyleLight21, TableStyleMedium1 through TableStyleMedium28, TableStyleStyleDark1 through TableStyleStyleDark11. A custom user-defined style present in the workbook can also be specified.|
 
 _See property access [examples.](#property-access-examples)_
 

--- a/word/word-add-ins-javascript-reference/font.md
+++ b/word/word-add-ins-javascript-reference/font.md
@@ -174,7 +174,7 @@ Word.run(function (context) {
     var selection = context.document.getSelection();
     
     // Queue a commmand to highlight the current selection.
-    selection.font.highlightColor = '#FFFF00'; //Yellow = 'Arial';
+    selection.font.highlightColor = '#FFFF00'; // Yellow
     
     // Synchronize the document state by executing the queued commands, 
     // and return a promise to indicate task completion.


### PR DESCRIPTION
The documentation for Table.Style is rather informal. Changed every occurrence of "thru" for its proper spelling.