### PR TITLE
Removing links to System.IO.Stream

### DIFF
--- a/reference/excel/chart.md
+++ b/reference/excel/chart.md
@@ -30,7 +30,7 @@ _See property access [examples.](#property-access-examples)_
 | Method		   | Return Type	|Description|
 |:---------------|:--------|:----------|
 |[delete()](#delete)|void|Deletes the chart object.|
-|[getImage(height: number, width: number, fittingMode: string)](#getimageheight-number-width-number-fittingmode-string)|[System.IO.Stream](system.io.stream.md)|Renders the chart as a base64-encoded image by scaling the chart to fit the specified dimensions.|
+|[getImage(height: number, width: number, fittingMode: string)](#getimageheight-number-width-number-fittingmode-string)|System.IO.Stream|Renders the chart as a base64-encoded image by scaling the chart to fit the specified dimensions.|
 |[load(param: object)](#loadparam-object)|void|Fills the proxy object created in the JavaScript layer with property and object values specified in the parameter.|
 |[setData(sourceData: Range, seriesBy: string)](#setdatasourcedata-range-seriesby-string)|void|Resets the source data for the chart.|
 |[setPosition(startCell: Range or string, endCell: Range or string)](#setpositionstartcell-range-or-string-endcell-range-or-string)|void|Positions the chart relative to cells on the worksheet.|
@@ -82,7 +82,7 @@ chartObject.getImage(height, width, fittingMode);
 |fittingMode|string|Optional. (Optional) The method used to scale the chart to the specified to the specified dimensions (if both height and width are set)."  Possible values are: Fit, FitAndCenter, Fill|
 
 #### Returns
-[System.IO.Stream](system.io.stream.md)
+System.IO.Stream
 
 #### Examples
 ```js


### PR DESCRIPTION
Need to add documentation on how to use System.IO.Stream in a JavaScript context before linking to it. Bug tracked on https://office.visualstudio.com/DefaultCollection/MAX/_workItems?id=589470&fullScreen=false&_a=edit