### PR TITLE
Fix version regex

### DIFF
--- a/docs/overview/schemas/taskpane/OfficeAppBasicTypesV1_0.xsd
+++ b/docs/overview/schemas/taskpane/OfficeAppBasicTypesV1_0.xsd
@@ -371,7 +371,7 @@
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:pattern value="([0-9]{1,5})(\.[0-9]{1,5}){0,3}?"/>
+      <xs:pattern value="([0-9]{1,5})(\.[0-9]{1,5}){0,3}"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
The additional '?' seems redundant and wrong: xmllint does not compile the XSD.