### PR TITLE
IDs must be unique

### DIFF
--- a/docs/outlook/manifests/define-add-in-commands.md
+++ b/docs/outlook/manifests/define-add-in-commands.md
@@ -173,7 +173,7 @@ Where:
 |**Element**|**Description**|
 |:-----|:-----|
 |**OfficeTab**|Required. The pre-existing tab to use. Currently, the  **id** attribute can only be "TabDefault".|
-|**Group**|A group of user interface extension points in a tab. A group can have up to six controls.The  **id** attribute is required. It is a string with a maximum of 125 characters.|
+|**Group**|A group of user interface extension points in a tab. A group can have up to six controls.The  **id** attribute is required and each **id** must be unique. It is a string with a maximum of 125 characters.|
 |**Label**|Required. The label of the group. The  **resid** attribute must be set to the value of the **id** attribute of a **String** element in the **ShortStrings** element in the **Resources** element.|
 |**Control**|A group requires at least one control. Currently, only buttons and menus are supported. See the following [Button controls](#VersionOverrides10_Buttons) and [Menu (dropdown button) controls](#menu-dropdown-button-controls) sections for more information.|
 
@@ -217,7 +217,7 @@ The button control looks like the following:
 </Control>
 ```
 
-Where the  **id** attribute is a string with a maximum of 125 characters and the button elements are described in the following table.
+Where the  **id** attribute is a *unique* string with a maximum of 125 characters and contains the button elements described in the following table.
 
 |**Button elements**|**Description**|
 |:-----|:-----|


### PR DESCRIPTION
Added language to denote that each group and button id attribute must be
a unique string.