### PR TITLE
Update BodyAsPlainText to Update BodyAsPlaintext

### DIFF
--- a/reference/manifest/rule.md
+++ b/reference/manifest/rule.md
@@ -49,7 +49,7 @@ Specifies the activation rule(s) that should be evaluated for this mail add-in.
 <Rule xsi:type="ItemHasRegularExpressionMatch" 
     RegExName="string " 
     RegExValue="string " 
-    PropertyName=["Subject" | "BodyAsPlainText" | "BodyAsHtml" | "SenderSTMPAddress"]
+    PropertyName=["Subject" | "BodyAsPlaintext" | "BodyAsHtml" | "SenderSTMPAddress"]
     IgnoreCase=["true" | "false"]
 />
 ```
@@ -135,7 +135,7 @@ None.
 |**PropertyName**|**Description**|
 |:-----|:-----|
 |Subject|Evaluates the regular expression against the item subject.|
-|BodyAsPlainText|Evaluates the regular expression against the item body in plain text.|
+|BodyAsPlaintext|Evaluates the regular expression against the item body in plain text.|
 |BodyAsHtml|Evaluates the regular expression against the item body if the body is available in HTML.|
 |SenderSTMPAddress|Evaluates the regular expression against the SMTP address of the item sender.|
 |


### PR DESCRIPTION
(Making the T lowercase in BodyAsPlainText.) When writing an Addin manifest in Outlook Web, the former would not be accepted, but the latter did.  Should probably confirm this is the expected behavior across Word/Excel/PPT, but this was definitely the case for Outlook Web.