### PR TITLE
Added add-in command pages to the reference section

### DIFF
--- a/docs/outlook/manifests/define-add-in-commands.md
+++ b/docs/outlook/manifests/define-add-in-commands.md
@@ -1,6 +1,6 @@
 # Define add-in commands in your Outlook add-in manifest
 
-To support add-in commands, some additional elements have been added to the add-in manifest v1.1 within the  **VersionOverrides** element. When a manifest contains the **VersionOverrides** element, versions of Outlook that support add-in commands will use the information within that element to load the add-in. Earlier versions of Outlook that do not support add-in commands will ignore the element and continue to use the elements as described in [Outlook add-in manifests](../../outlook/manifests/manifests.md).
+To support add-in commands, some additional elements have been added to the add-in manifest v1.1 within the [VersionOverrides](../../../reference/manifest/commands/versionoverrides.md) element. When a manifest contains the **VersionOverrides** element, versions of Outlook that support add-in commands will use the information within that element to load the add-in. Earlier versions of Outlook that do not support add-in commands will ignore the element and continue to use the elements as described in [Outlook add-in manifests](../../outlook/manifests/manifests.md).
 
 When the client application recognizes the  **VersionOverrides** node, the add-in name appears in the ribbon, not in the read/compose pane. The add-in won't appear in both places.
  

--- a/docs/word/word-add-ins-programming-overview.md
+++ b/docs/word/word-add-ins-programming-overview.md
@@ -1,5 +1,5 @@
 
-# Word add-ins
+# Word add-ins overview
 
 Do you want to create a solution that extends the functionality of Word - for example, one that involves automated document assembly, or that binds to and accesses data in a Word document from other data sources? You can use the Office Add-ins platform, which includes the Word JavaScript API and the JavaScript API for Office, to extend Word clients running on a Windows desktop, on a Mac, or in the cloud.
 

--- a/reference/manifest/commands/action.md
+++ b/reference/manifest/commands/action.md
@@ -1,0 +1,40 @@
+# Action Element
+ Specifies the action to perform when the user selects a  [Button](./button-control.md) or [Menu](./menu-control.md) controls.
+ 
+ ## Attributes
+
+|  Attribute  |  Required  |  Description  |
+|:-----|:-----|:-----|
+|  [xsi:type](#xsitype)  |  Yes  | Action type to take|
+
+
+## Child elements
+
+|  Element |  Description  |
+|:-----|:-----|
+|  [FunctionName](#functionname) |    Specifies the name of the function to execute. |
+|  [SourceLocation](#sourcelocation) |    Specifies the source file location for this action. |
+  
+
+## xsi:type
+This attribute specifies the kind of action performed when the user selects the button. It can be one of the following
+- ExecuteFunction
+- ShowTaskpane
+
+## FunctionName
+Required element when **xsi:type** is "ExecuteFunction". Specifies the name of the function to execute. The function is contained in the file specified in the [FunctionFile](./functionfile.md) element.
+
+```xml
+<Action xsi:type="ExecuteFunction">
+    <FunctionName>getSubject</FunctionName>
+</Action>
+```
+
+## SourceLocation
+Required element when  **xsi:type** is "ShowTaskpane". Specifies the source file location for this action. The **resid** attribute must be set to the value of the **id** attribute of a **Url** element in the [Urls](./resources.md#urls) element in the [Resources](./resources.md) element.
+
+```xml
+ <Action xsi:type="ShowTaskpane">
+    <SourceLocation resid="readTaskPaneUrl" />
+  </Action>
+```  

--- a/reference/manifest/commands/appointmentattendeecommandsurface.md
+++ b/reference/manifest/commands/appointmentattendeecommandsurface.md
@@ -1,0 +1,27 @@
+# AppointmentAttendeeCommandSurface
+
+This puts buttons on the ribbon for the form that's displayed to the attendee of the meeting. 
+
+## Child elements
+|  Element |  Description  |
+|:-----|:-----|
+|  [OfficeTab](./officetab.md) |  Adds the command(s) to the default ribbon tab.  |
+|  [CustomTab](./customtab.md) |  Adds the command(s) to the custom ribbon tab.  |
+
+## OfficeTab example
+```xml
+<ExtensionPoint xsi:type="AppointmentAttendeeCommandSurface">
+  <OfficeTab id="TabDefault">
+        <-- OfficeTab Definition -->
+  </OfficeTab>
+</ExtensionPoint>
+```
+
+##  CustomTab example
+```xml
+<ExtensionPoint xsi:type="AppointmentAttendeeCommandSurface">
+  <CustomTab id="TabCustom1">
+        <-- CustomTab Definition -->
+  </CustomTab>
+</ExtensionPoint>
+```

--- a/reference/manifest/commands/appointmentorganizercommandsurface.md
+++ b/reference/manifest/commands/appointmentorganizercommandsurface.md
@@ -1,0 +1,27 @@
+# AppointmentOrganizerCommandSurface
+
+This puts buttons on the ribbon for the form that's displayed to the organizer of the meeting. 
+
+## Child elements
+|  Element |  Description  |
+|:-----|:-----|
+|  [OfficeTab](./officetab.md) |  Adds the command(s) to the default ribbon tab.  |
+|  [CustomTab](./customtab.md) |  Adds the command(s) to the custom ribbon tab.  |
+
+## OfficeTab example
+```xml
+<ExtensionPoint xsi:type="AppointmentOrganizerCommandSurface">
+  <OfficeTab id="TabDefault">
+        <-- OfficeTab Definition -->
+  </OfficeTab>
+</ExtensionPoint>
+```
+
+##  CustomTab example
+```xml
+<ExtensionPoint xsi:type="AppointmentOrganizerCommandSurface">
+  <CustomTab id="TabCustom1">
+        <-- CustomTab Definition -->
+  </CustomTab>
+</ExtensionPoint>
+```

--- a/reference/manifest/commands/button-control.md
+++ b/reference/manifest/commands/button-control.md
@@ -1,0 +1,62 @@
+#Button controls
+
+A button performs a single action when the user selects it. It can either execute a function or show a task pane. Each button control must have an `id` unique to the manifest. 
+
+## Child elements
+|  Element |  Required  |  Description  |
+|:-----|:-----|:-----|
+|  [Label](#label)     | Yes |  The text for the button.         |
+|  [Supertip](./supertip.md)  | Yes |  The supertip for this button.    |
+|  [Icon](./icon.md)      | Yes |  An image for the button.         |
+|  [Action](./action.md)    | Yes |  Specifies the action to perform  |
+
+## Label
+Required. The text for the button. The  **resid** attribute must be set to the value of the **id** attribute 
+of a **String** element in the [ShortStrings](./resources.md#shortstrings) element in the [Resources](./resources.md)  element.
+
+## Supertip
+Required. See [Supertip](./supertip.md).
+ 
+## Icon
+Required. See [Icon](./icon.md).
+
+## Action
+Required. See [Action](./action.md).
+
+## ExecuteFunction button example
+```xml
+<Control xsi:type="Button" id="msgReadFunctionButton">
+  <Label resid="funcReadButtonLabel" />
+  <Supertip>
+    <Title resid="funcReadSuperTipTitle" />
+    <Description resid="funcReadSuperTipDescription" />
+  </Supertip>
+  <Icon>
+    <bt:Image size="16" resid="blue-icon-16" />
+    <bt:Image size="32" resid="blue-icon-32" />
+    <bt:Image size="80" resid="blue-icon-80" />
+  </Icon>
+  <Action xsi:type="ExecuteFunction">
+    <FunctionName>getSubject</FunctionName>
+  </Action>
+</Control>
+```
+
+## ShowTaskpane button example
+```xml
+<Control xsi:type="Button" id="msgReadOpenPaneButton">
+  <Label resid="paneReadButtonLabel" />
+  <Supertip>
+    <Title resid="paneReadSuperTipTitle" />
+    <Description resid="paneReadSuperTipDescription" />
+  </Supertip>
+  <Icon>
+    <bt:Image size="16" resid="green-icon-16" />
+    <bt:Image size="32" resid="green-icon-32" />
+    <bt:Image size="80" resid="green-icon-80" />
+  </Icon>
+  <Action xsi:type="ShowTaskpane">
+    <SourceLocation resid="readTaskPaneUrl" />
+  </Action>
+</Control>
+```

--- a/reference/manifest/commands/custompane.md
+++ b/reference/manifest/commands/custompane.md
@@ -1,0 +1,37 @@
+# CustomPane
+
+The CustomPane [extension point](./extensionpoint.md) defines an add-in that activates when specified rules are satisfied. It is only for read form and it displays in a horizontal pane. The following are the elements of the **CustomPane**.
+
+## Child elements
+
+|  Element |  Required  |  Description  |
+|:-----|:-----|:-----|
+|  [RequestedHeight](#requestedheight) | No |  The requested height in pixels.  |
+|  [SourceLocation](#sourcelocation)  | Yes |  he URL for the source code file of the add-in.  |
+|  [Rule](#rule)  | Yes |  The rule or collection of rules that specify when the add-in activates.  |
+|  [DisableEntityHighlighting](#disableentityhighlighting)  | No |  Specifies whether entity highlighting should be turned off. |
+
+## RequestedHeight
+Optional. The requested height, in pixels, for the display pane when it is running on a desktop computer. This can be from 32 to 450 pixels. It is the same as in read add-ins (see [RequestedHeight element](http://msdn.microsoft.com/library/6296f5b0-3d5b-5ab9-eee9-55a7eb90f92c%28Office.15%29.aspx)
+
+## SourceLocation
+Required. The URL for the source code file of the add-in. This refers to a  **Url** element in the [Resources](./resources.md)  element.
+
+## Rule
+Required. The rule or collection of rules that specify when the add-in activates. It is the same as defined in [Outlook add-in manifests](../../outlook/manifests/manifests.md), except the [ItemIs](http://msdn.microsoft.com/en-us/library/f7dac4a3-1574-9671-1eda-47f092390669%28Office.15%29.aspx) rule has the following changes: **ItemType** is either "Message" or "AppointmentAttendee", and there is no **FormType** attribute. For more information, see [Custom pane Outlook add-ins](../../outlook/custom-pane-outlook-add-ins.md) and [Activation rules for Outlook add-ins](../../outlook/manifests/activation-rules.md).
+
+## DisableEntityHighlighting
+Optional. Specifies whether entity highlighting should be turned off for this mail add-in. 
+
+## CustomPane example
+```xml
+<ExtensionPoint xsi:type="CustomPane">
+   <RequestedHeight>100< /RequestedHeight> 
+   <SourceLocation resid="residReadTaskpaneUrl"/>
+   <Rule xsi:type="RuleCollection" Mode="Or">
+     <Rule xsi:type="ItemIs" ItemType="Message"/>
+     <Rule xsi:type="ItemHasAttachment"/>
+     <Rule xsi:type="ItemHasKnownEntity" EntityType="Address"/>
+   </Rule>
+</ExtensionPoint>
+```

--- a/reference/manifest/commands/customtab.md
+++ b/reference/manifest/commands/customtab.md
@@ -1,0 +1,33 @@
+# Custom tab
+On the ribbon, you specify which tab and group for their add-in commands. This can either be on the default tab (either  **Home**,  **Message**, or  **Meeting**), or on a custom tab defined by the add-in.
+
+On custom tabs, the add-in can create up to 10 groups. Each group is limited to 6 controls, regardless of which tab it appears on. Add-ins are limited to one custom tab.
+
+## Child elements
+|  Element |  Required  |  Description  |
+|:-----|:-----|:-----|
+|  [CustomTab](#customtab)  | Yes |  Defines a custom ribbon tab.  |
+|  [Group](./group.md)      | Yes |  Defines a Group of commands.  |
+|  [Label](#label)      | Yes |  The label for the CustomTab or a Group  |
+|  [Control](#control)    | Yes |  Collection of one or more Control objects  |
+
+## CustomTab
+Required. The  **id** attribute must be unique within the manifest.
+
+## Group
+Required. See [Group element](./group.md).
+
+## Label (Tab)
+Required. The label of the custom tab. The  **resid** attribute must be set to the value of the **id** attribute of a **String** element in the [ShortStrings](./resources.md#shortstrings) element in the [Resources](./resources.md) element.
+
+
+##  CustomTab example
+```xml
+<ExtensionPoint xsi:type="MessageReadCommandSurface">
+  <CustomTab id="TabCustom1">
+    <Group id="msgreadCustomTab.grp1">
+    </Group>
+    <Label resid="customTabLabel1"/>
+  </CustomTab>
+</ExtensionPoint>
+```

--- a/reference/manifest/commands/extensionpoint.md
+++ b/reference/manifest/commands/extensionpoint.md
@@ -1,0 +1,22 @@
+# ExtensionPoint element
+
+The  **ExtensionPoint** element defines where an add-in exposes functionality. It is a child element under [FormFactor](./formfactor.md). 
+
+## Attributes
+
+|  Attribute  |  Required  |  Description  |
+|:-----|:-----|:-----|
+|  [xsi:type](#xsitype)  |  Yes  | The type of ExtentionPoint being defined|
+
+## xsi:type
+For each form factor, you can define **ExtensionPoint** elements with the following **xsi:type** values, with the exception of the **Module** value which can only be used in the [DesktopFormFactor](./formfactor.md):
+
+- [CustomPane](./custompane.md) 
+- [MessageReadCommandSurface](./messagereadcommandsurface.md) 
+- [MessageComposeCommandSurface](./messagecomposecommandsurface.md) 
+- [AppointmentOrganizerCommandSurface](./appointmentorganizercommandsurface.md) 
+- [AppointmentAttendeeCommandSurface](./appointmentattendeecommandsurface.md)
+- [Module](./module.md)
+
+
+

--- a/reference/manifest/commands/formfactor.md
+++ b/reference/manifest/commands/formfactor.md
@@ -1,0 +1,33 @@
+# FormFactor element
+
+The  **FormFactor** element specifies the settings for an add-in for a given form factor. As an example, defining a `Host` with the type `MailHost` and `DesktopFormFactor` will apply to Outlook for Desktop but  _not_ Outlook Web App or Outlook.com. It contains all the add-in information for that form factor except for the  **Resources** node.
+
+Each FormFactor definition contains the  **FunctionFile** element and one or more **ExtensionPoint** elements. For more information see the following [FunctionFile element](./functionfile.md) and [ExtensionPoint element](./extensionpoint.md) sections. The following is an example of **FormFactor**, showing its child nodes.
+
+The following are the FormFactors are supported:
+
+- `DesktopFormFactor` (Office for Windows or Mac clients)
+
+## Child elements
+
+|  Element |  Required  |  Description  |
+|:-----|:-----|:-----|
+|  [FunctionFile](./functionfile.md)      | Yes |  Url to file containing JavaScript functions  |
+|  [ExtensionPoint](./extensionpoint.md)  | Yes |  Defines where an add-in exposes functionality  |
+
+## FormFactor example
+```xml
+...
+<Hosts>
+  <Host xsi:type="MailHost">
+    <DesktopFormFactor>
+      <FunctionFile resid="residDesktopFuncUrl" />
+      <ExtensionPoint xsi:type="CustomPane">
+        <!-- information on this extension point -->
+      </ExtensionPoint> 
+      <!-- possibly more ExtensionPoint elements -->
+    </DesktopFormFactor>
+  </Host>
+</Hosts>
+...
+```

--- a/reference/manifest/commands/functionfile.md
+++ b/reference/manifest/commands/functionfile.md
@@ -1,0 +1,20 @@
+# FunctionFile element
+
+The  **FunctionFile** element is a child element under [FormFactor](./formfactor). It specifies the source code file for operations that an add-in exposes through add-in commands that execute a JavaScript function instead of displaying UI. The **resid** attribute of the **FunctionFile** element is set to the value of the **id** attribute of a **Url** element in the **Resources** element that contains the URL to an HTML file that contains or loads all of the JavaScript functions used by UI-less add-in command buttons. For more information, see the [Button controls](#button-controls) section of this article.
+
+The JavaScript in the HTML file indicated by the  **FunctionFile** element must call `Office.initialize` and define named functions that take a single parameter: `event`. The functions should use the [item.notificationMessages](../../../reference/outlook/Office.context.mailbox.item.md) API to indicate progress, success, or failure to the user. It should also call [event.completed](../../../reference/shared/event.completed.md) when it has finished execution. The name of the functions are used in the **FunctionName** element for UI-less buttons.
+
+The following is an example of an HTML file defining a trackMessage function.
+
+```javascript
+Office.intialize = function () {
+    doAuth();
+}
+
+function trackMessage (event) {
+    var buttonId = event.source.id;    
+    var itemId = Office.context.mailbox.item.id;
+    // save this message
+    event.completed();
+}
+```

--- a/reference/manifest/commands/group.md
+++ b/reference/manifest/commands/group.md
@@ -1,0 +1,33 @@
+# Group element
+A group of user interface extension points in a tab.  On custom tabs, the add-in can create up to 10 groups. Each group is limited to 6 controls, regardless of which tab it appears on. Add-ins are limited to one custom tab.
+
+## Attributes
+
+|  Attribute  |  Required  |  Description  |
+|:-----|:-----|:-----|
+|  [id](#xsitype)  |  Yes  | Unique ID for the group.|
+
+## Child elements
+|  Element |  Required  |  Description  |
+|:-----|:-----|:-----|
+|  [Label](#label)      | Yes |  The label for the CustomTab or a Group  |
+|  [Control](#control)    | Yes |  Collection of one or more Control objects  |
+
+## id attribute
+Required. Unique identifier for the Group. It is a string with a maximum of 125 characters. This must be unique within the manifest or the Group will fail to render.
+
+## Label 
+Required. The label of the group. The  **resid** attribute must be set to the value of the **id** attribute of a **String** element in the [ShortStrings](./resources.md#shortstrings) element in the [Resources](./resources.md) element.
+
+## Control
+A group requires at least one control. Currently, only buttons and menus are supported. See the following [Button controls](#button-controls) and[Menu (dropdown button) controls](#menu-dropdown-button-controls) sections for more information.
+
+```xml
+<Group id="msgreadCustomTab.grp1">
+    <Label resid="residCustomTabGroupLabel"/>
+    <Control xsi:type="Button" id="Button2">
+    <!-- information on the control -->
+    </Control>
+    <!-- other controls, as needed -->
+</Group>
+```

--- a/reference/manifest/commands/hosts.md
+++ b/reference/manifest/commands/hosts.md
@@ -1,0 +1,47 @@
+# Hosts Element
+
+This contains a collection of host objects and their settings. It overrides the  Hosts element in the parent portion of the manifest. Hosts is a child of the [VersionOverrides](./versionoverrides.md) element.
+
+## Child elements
+
+|  Element |  Required  |  Description  |
+|:-----|:-----|:-----|
+|  [Host](#host-element)    |  Yes   |  Describes a host and it's settings. |
+
+> ** Note: ** Outlook requires `Hosts`to contain a `Host` definition for `MailHost`
+
+---- 
+
+# Host Element
+
+## Attributes
+
+|  Attribute  |  Required  |  Description  |
+|:-----|:-----|:-----|
+|  [xsi:type](#xsitype)  |  Yes  | Describes the Office host these settings apply to.|
+
+## Child elements
+
+|  Element |  Required  |  Description  |
+|:-----|:-----|:-----|
+|  [FormFactor](./formfactor.md)    |  Yes   |  Defines the form factor affected. |
+
+
+## xsi:type
+This controls which Office "host" (Word, PowerPoint, Outlook, etc) the contained settings apply too. The value must be one of the following:
+
+- `MailHost` (Outlook)    
+
+
+## FormFactor
+See [FormFactor](./formfactor.md)
+
+
+## Hosts Example 
+```xml
+<Hosts>
+    <Host xsi:type="MailHost">
+        <!-- Host Settings -->
+    </Host>
+</Hosts>
+```

--- a/reference/manifest/commands/icon.md
+++ b/reference/manifest/commands/icon.md
@@ -1,0 +1,19 @@
+# Icon Element
+Defines **Image** elements for [Button](./button-control.md) and [Menu](./menu-control.md) controls.
+
+## Child elements
+|  Element |  Required  |  Description  |
+|:-----|:-----|:-----|
+|  [Image](#image)        | Yes |   resid of an image to use         |
+
+## Image
+An image for the button. The  **resid** attribute must be set to the value of the **id** attribute of an **Image** element in the **Images** element in the [Resources](./resources.md) element. The **size** attribute indicates the size in pixels of the image. Three image sizes are required (16, 32, and 80 pixels) while five other sizes are supported (20, 24, 40, 48, and 64 pixels).|
+
+
+```xml
+  <Icon>
+    <bt:Image size="16" resid="blue-icon-16" />
+    <bt:Image size="32" resid="blue-icon-32" />
+    <bt:Image size="80" resid="blue-icon-80" />
+  </Icon>
+```  

--- a/reference/manifest/commands/menu-control.md
+++ b/reference/manifest/commands/menu-control.md
@@ -1,0 +1,58 @@
+# Menu (dropdown button) controls
+
+A menu defines a static list of options. Each menu item either executes a function or shows a task pane. Submenus are not supported. 
+
+## Child elements
+
+|  Element |  Required  |  Description  |
+|:-----|:-----|:-----|
+|  [Label](#label)     | Yes |  The text for the button.         |
+|  [Supertip](./supertip.md)  | Yes |  The supertip for this button.    |
+|  [Icon](./icon.md)      | Yes |  An image for the button.         |
+|  [Items](#items)     | Yes |  Collection of Buttons to display within the menu |
+
+## Label
+Required. The text for the button. The  **resid** attribute must be set to the value of the **id** attribute 
+of a **String** element in the [ShortStrings](./resources.md#shortstrings) element in the [Resources](./resources.md) element.
+
+## Supertip
+Required. See [Supertip](./supertip.md).
+ 
+## Icon
+Required. See [Icon](./icon.md).
+
+## Items
+Required. Contains the  **Item** elements for the menu. Each **Item** element contains the same child elements as a [Button controls](./button-control.md).
+
+## Menu control example
+```xml
+<Control xsi:type="Menu" id="msgReadMenuButton">
+  <Label resid="menuReadButtonLabel" />
+  <Supertip>
+    <Title resid="menuReadSuperTipTitle" />
+    <Description resid="menuReadSuperTipDescription" />
+  </Supertip>
+  <Icon>
+    <bt:Image size="16" resid="red-icon-16" />
+    <bt:Image size="32" resid="red-icon-32" />
+    <bt:Image size="80" resid="red-icon-80" />
+  </Icon>
+  <Items>
+    <Item id="msgReadMenuItem1">
+      <Label resid="menuItem1ReadLabel" />
+      <Supertip>
+        <Title resid="menuItem1ReadLabel" />
+        <Description resid="menuItem1ReadTip" />
+      </Supertip>
+      <Icon>
+        <bt:Image size="16" resid="red-icon-16" />
+        <bt:Image size="32" resid="red-icon-32" />
+        <bt:Image size="80" resid="red-icon-80" />
+      </Icon>
+      <Action xsi:type="ExecuteFunction">
+        <FunctionName>getItemClass</FunctionName>
+      </Action>
+    </Item>
+  </Items>
+</Control>
+```

--- a/reference/manifest/commands/messagecomposecommandsurface.md
+++ b/reference/manifest/commands/messagecomposecommandsurface.md
@@ -1,0 +1,27 @@
+# MessageComposeCommandSurface
+
+This puts buttons on the ribbon for add-ins using mail compose form. 
+
+## Child elements
+|  Element |  Description  |
+|:-----|:-----|
+|  [OfficeTab](./officetab.md) |  Adds the command(s) to the default ribbon tab.  |
+|  [CustomTab](./customtab.md) |  Adds the command(s) to the custom ribbon tab.  |
+
+## OfficeTab example
+```xml
+<ExtensionPoint xsi:type="MessageComposeCommandSurface">
+  <OfficeTab id="TabDefault">
+        <-- OfficeTab Definition -->
+  </OfficeTab>
+</ExtensionPoint>
+```
+
+##  CustomTab example
+```xml
+<ExtensionPoint xsi:type="MessageComposeCommandSurface">
+  <CustomTab id="TabCustom1">
+        <-- CustomTab Definition -->
+  </CustomTab>
+</ExtensionPoint>
+```

--- a/reference/manifest/commands/messagereadcommandsurface.md
+++ b/reference/manifest/commands/messagereadcommandsurface.md
@@ -1,0 +1,27 @@
+# MessageReadCommandSurface
+
+This [extension point](./extensionpoint.md) puts buttons in the command surface for the mail read view. In Outlook desktop, this appears in the ribbon.
+
+## Child elements
+|  Element |  Description  |
+|:-----|:-----|
+|  [OfficeTab](./officetab.md) |  Adds the command(s) to the default ribbon tab.  |
+|  [CustomTab](./customtab.md) |  Adds the command(s) to the custom ribbon tab.  |
+
+## OfficeTab example
+```xml
+<ExtensionPoint xsi:type="MessageReadCommandSurface">
+  <OfficeTab id="TabDefault">
+        <-- OfficeTab Definition -->
+  </OfficeTab>
+</ExtensionPoint>
+```
+
+##  CustomTab example
+```xml
+<ExtensionPoint xsi:type="MessageReadCommandSurface">
+  <CustomTab id="TabCustom1">
+        <-- CustomTab Definition -->
+  </CustomTab>
+</ExtensionPoint>
+```

--- a/reference/manifest/commands/module.md
+++ b/reference/manifest/commands/module.md
@@ -1,0 +1,9 @@
+# Module
+
+This puts buttons on the ribbon for the module extension. 
+
+## Child elements
+|  Element |  Description  |
+|:-----|:-----|
+|  [OfficeTab](./officetab.md) |  Adds the command(s) to the default ribbon tab.  |
+|  [CustomTab](./customtab.md) |  Adds the command(s) to the custom ribbon tab.  |

--- a/reference/manifest/commands/officetab.md
+++ b/reference/manifest/commands/officetab.md
@@ -1,0 +1,27 @@
+# Office tab
+On the ribbon, you specify which tab and group for their add-in commands. This can either be on the default tab (either  **Home**,  **Message**, or  **Meeting**), or on a custom tab defined by the add-in. 
+
+The default tab is limited to one group per add-in. 
+
+## Child elements
+|  Element |  Required  |  Description  |
+|:-----|:-----|:-----|
+|  OfficeTab  | Yes |  Always set to `TabDefault`.  |
+|  Group      | Yes |  Defines a Group of commands.  |
+
+## OfficeTab
+Required. The pre-existing tab to use. Currently, the  **id** attribute can only be "TabDefault".
+
+## Group
+A group of user interface extension points in a tab. A group can have up to six controls. The  **id** attribute is required and each **id** must be unique within the manifest. It is a string with a maximum of 125 characters. See [Group element](./group.md).
+
+## OfficeTab example
+```xml
+<ExtensionPoint xsi:type="MessageReadCommandSurface">
+  <OfficeTab id="TabDefault">
+    <Group id="msgreadTabMessage.grp1">
+        <!-- Group Definition -->
+    </Group>
+  </OfficeTab>
+</ExtensionPoint>
+```

--- a/reference/manifest/commands/resources.md
+++ b/reference/manifest/commands/resources.md
@@ -1,0 +1,66 @@
+# Resources Element
+
+The **Resources** element contains icons, strings, and URLs for the [VersionOverrides](./versionoverrides.md) node. A manifest element specifies a resource by using the **Id** of the resource. This helps to keep the size of the manifest manageable, especially when resources have versions for different locales. An **Id** must be unique within the manifest and has a maximum of 32 characters.
+
+The  **Resources** node defines the following resources. Each resource can have one or more **Override** child elements to define a resource for specific locales.
+
+## Child elements
+
+|  Element |  Type  |  Description  |
+|:-----|:-----|:-----|
+|  [Images](#images)            |  image   |  Provides the HTTPS URL to an image for an icon. |
+|  [Urls](#urls)                |  url     |  Provides an HTTPS URL location. |
+|  [ShotStrings](#shortstrings) |  string  |  The text for Label and Title elements. |
+|  [LongStrings](#longstrings)  |  string  | The text for Description attributes. |
+
+## Images
+Provides the HTTPS URL to an image for an icon. Each icon must have three  **Image** elements, one for each of the three mandatory sizes:
+- 16x16
+- 32x32
+- 80x80
+
+The following additional sizes are also supported, but not required:
+- 20x20
+- 24x24
+- 40x40
+- 48x48
+- 64x64
+
+> **Important: ** Outlook requires the ability to cache image resources for performance purposes. For this reason, the server hosting an image resource must not add any CACHE-CONTROL directives to the response header. This will result in Outlook automatically substituting a generic or default image.    
+
+## Urls
+Provides an HTTPS URL location. A URL can be a maximum of 2048 characters. 
+
+## ShortStrings
+The text for  **Label** and **Title** elements. Each **String** contains a maximum of 125 characters.
+
+## LongStrings
+The text for  **Description** attributes. Each **String** contains a maximum of 250 characters.
+
+## Resources example 
+```xml
+<Resources>
+  <bt:Images>
+    <!-- Blue icon -->
+    <bt:Image id="blue-icon-16" DefaultValue="YOUR_WEB_SERVER/images/blue-16.png"/>
+    <bt:Image id="blue-icon-32" DefaultValue="YOUR_WEB_SERVER/images/blue-32.png"/>
+    <bt:Image id="blue-icon-80" DefaultValue="YOUR_WEB_SERVER/images/blue-80.png"/>
+  </bt:Images>
+  <bt:Urls>
+    <bt:Url id="functionFile" DefaultValue="YOUR_WEB_SERVER/FunctionFile/Functions.html"/>
+    <!-- other URLs -->
+  </bt:Urls>
+  <bt:ShortStrings>
+    <bt:String id="groupLabel" DefaultValue="Add-in Demo">
+      <bt:Override Locale="ar-sa" Value="<Localized text>" />
+    </bt:String>
+    <!-- Other short strings -->
+  </bt:ShortStrings>
+  <bt:LongStrings>
+    <bt:String id="funcReadSuperTipDescription" DefaultValue="Gets the subject of the message or appointment.">
+      <bt:Override Locale="ar-sa" Value="<Localized text>." />
+    </bt:String>
+    <!-- Other long strings -->
+  </bt:LongStrings>
+</Resources>
+```

--- a/reference/manifest/commands/supertip.md
+++ b/reference/manifest/commands/supertip.md
@@ -1,0 +1,21 @@
+## Supertip
+The Supertip object defines a rich tooltip (both Title and Description). It is used by both [Button](./button-control.md) and [Menu](./menu-control.md) controls. 
+
+## Child elements
+|  Element |  Required  |  Description  |
+|:-----|:-----|:-----|
+|  [Title](#title)        | Yes |   The text for the supertip         |
+|  [Description](#description)  | Yes |  The description for the supertip.    |
+
+## Title
+Required. The text for the supertip. The  **resid** attribute must be set to the value of the **id** attribute of a **String** element in the [ShortStrings](./resources.md#shortstrings) element in the [Resources](./resources.md) element.
+
+## Description
+Required. The description for the supertip. The  **resid** attribute must be set to the value of the **id** attribute of a **String** element in the [LongStrings](./resources.md#longstrings) element in the [Resources](./resources.md) element.
+
+```xml
+ <Supertip>
+    <Title resid="funcReadSuperTipTitle" />
+    <Description resid="funcReadSuperTipDescription" />
+  </Supertip>
+```

--- a/reference/manifest/commands/versionoverrides.md
+++ b/reference/manifest/commands/versionoverrides.md
@@ -1,0 +1,62 @@
+# VersionOverrides Element
+
+The  **VersionOverrides** element is the root element that contains information for the add-in commands implemented by the add-in. It is supported in manifest schema v1.1 or later but is defined in the VersionOverrides v1.0 schema. The attributes for **VersionOverrides** are as follows.
+
+## Attributes
+
+|  Attribute  |  Required  |  Description  |
+|:-----|:-----|:-----|
+|  [xmlns](#xmlns)       |  Yes  |  The schema location. Must be `http://schemas.microsoft.com/office/mailappversionoverrides`|
+|  [xsi:type](#xsitype)  |  Yes  | The schema version. The version described in this topic is `VersionOverridesV1_0`.|
+
+
+## Child elements
+
+|  Element |  Required  |  Description  |
+|:-----|:-----|:-----|
+|  [Description](#description)    |  No   |  Describes the add-in. |
+|  [Requirements](#requirements)  |  No   |  Minimum Mailbox version required | 
+|  [Hosts](./hosts.md)                |  Yes  |  Collection of host types and their settings |
+|  [Resources](./resources.md)    |  Yes  | Resource definitions (strings, URLs, and images)  |
+
+
+### xmlns 
+This is a required attribute which defines the schema location. The value should always be defined as `http://schemas.microsoft.com/office/mailappversionoverrides`.
+
+### xsi:type
+This is a required attribute which defines the schema version. At this time the only valid value is `VersionOverridesV1_0`.  
+
+### Description
+Describes the add-in. This overrides the `Description` element in any parent portion of the manifest. The text of the description is contained in a child element of the LongString element contained in the [Resources](./resources.md) element. The `resid` attribute of the Description element is set to the value of the `id` attribute of the `String` element that contains the text.
+
+### Requirements
+Specifies the minimum requirement set and version of Office.js that the Office add-in needs to activate. It is defined the same as in [Outlook add-in manifests](../requirments.md). This overrides the  `Requirements` element in the parent portion of the manifest.
+
+### Hosts
+See [Hosts](./hosts.md).
+
+### Resources 
+See [Resources](./resources.md).
+
+
+### VersionOverrides example
+```xml
+<OfficeApp>
+...
+  <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">
+    <Description resid="residDescription" />
+    <Requirements>
+      <!-- add information on requirements -->
+    </Requirements>
+    <Hosts>
+      <Host xsi:type="MailHost">
+        <!-- add information on form factors -->
+      </Host>
+    </Hosts>
+    <Resources> 
+      <!-- add information on resources -->
+   </Resources>
+</VersionOverrides>
+...
+</OfficeApp>
+```

--- a/reference/outlook/1.2/Office.context.mailbox.item.md
+++ b/reference/outlook/1.2/Office.context.mailbox.item.md
@@ -1395,6 +1395,6 @@ Asynchronously inserts data into the body or subject of a message.
 ##### Example
 
 ```JavaScript
-Office.context.mailbox.item.setSelectedDataAsync(“Hello World!”);
-Office.context.mailbox.item.setSelectedDataAsync(“<b>Hello World!</b>”, { coercionType : “html” });
+Office.context.mailbox.item.setSelectedDataAsync("Hello World!");
+Office.context.mailbox.item.setSelectedDataAsync("<b>Hello World!</b>", { coercionType : "html" });
 ```

--- a/reference/outlook/NotificationMessages.md
+++ b/reference/outlook/NotificationMessages.md
@@ -93,6 +93,7 @@ Office.context.mailbox.item.notificationMessages.getAllAsync(function (asyncResu
       persistent: false
     });
   }
+});
 ```
 
 ####  removeAsync(key, [options], [callback])

--- a/reference/outlook/Office.context.mailbox.item.md
+++ b/reference/outlook/Office.context.mailbox.item.md
@@ -1464,6 +1464,6 @@ Asynchronously inserts data into the body or subject of a message.
 ##### Example
 
 ```
-Office.context.mailbox.item.setSelectedDataAsync(“Hello World!”);
-Office.context.mailbox.item.setSelectedDataAsync(“<b>Hello World!</b>”, { coercionType : “html” });
+Office.context.mailbox.item.setSelectedDataAsync("Hello World!");
+Office.context.mailbox.item.setSelectedDataAsync("<b>Hello World!</b>", { coercionType : "html" });
 ```

--- a/reference/word/word-add-ins-reference-overview.md
+++ b/reference/word/word-add-ins-reference-overview.md
@@ -4,14 +4,14 @@ Word provides a rich set of APIs that you can use to create add-ins that interac
 
 You can use two JavaScript APIs to interact with the objects and metadata in a Word document:
 
-- [JavaScript API for Office](../javascript-api-for-office.md) (Office.js) - Introduced in Office 2013.
 - Word JavaScript API - Introduced in Office 2016.
+- [JavaScript API for Office](../javascript-api-for-office.md) (Office.js) - Introduced in Office 2013.
 
 ## Word JavaScript API
 
 The Word JavaScript API is loaded by Office.js. The Word JavaScript API changes the way that you can interact with objects like documents and paragraphs. Rather than providing individual asynchronous APIs for retrieving and updating each of these objects, the Word JavaScript API provides “proxy” JavaScript objects that correspond to the real objects running in Word. You can interact with these proxy objects by synchronously reading and writing their properties and calling synchronous methods to perform operations on them. These interactions with proxy objects aren’t immediately realized in the running script. The **context.sync** method synchronizes the state between your running JavaScript and the real objects in Office by executing queued instructions and retrieving properties of loaded Word objects for use in your script.
 
-## Get the JavaScript API for Office
+## JavaScript API for Office
 
 You can reference Office.js from the following locations:
 
@@ -116,6 +116,6 @@ As we design and develop new APIs for Word add-ins, we'll make them available fo
 
 ## Additional resources
 
-* [Word add-in development overview](../../docs/word/word-add-ins-programming-overview.md )
+* [Word add-ins overview](../../docs/word/word-add-ins-programming-overview.md )
 * [Office Add-ins platform overview](../../docs/overview/office-add-ins.md)
 * [Word add-in samples on GitHub](https://github.com/OfficeDev?utf8=%E2%9C%93&query=Word)


### PR DESCRIPTION
The current single-page documentation for add-in commands was getting
very hard to navigate or reference via links.