### PR TITLE
Added clarifying note that Vorlon needs to have https enabled

### DIFF
--- a/docs/testing/debug-office-add-ins-on-ipad-and-mac.md
+++ b/docs/testing/debug-office-add-ins-on-ipad-and-mac.md
@@ -22,6 +22,8 @@ To install and set up up Vorlon:
 <script src="http://localhost:1337/vorlon.js"></script>    
 ```  
 
+>**Note:** Note: using Vorlon.js for add-in debugging requires that https is enabled in Vorlon. To learn how to do that, see [VorlonJS plugin for debugging Office Addin](https://blogs.msdn.microsoft.com/mim/2016/02/18/vorlonjs-plugin-for-debugging-office-addin/)
+
 Now, whenever you open the add-in on a device, it will show up in the list of Clients in Vorlon (on the left side of the Vorlon interface). You can remotely highlight DOM elements, remotely execute commands, and much more.  
 
 ![Screenshot that shows the Vorlon.js interface](../../images/vorlon_interface.png)


### PR DESCRIPTION
Added because users may not know about this and it's crucial for using Vorlon.