### PR TITLE
Correct name for add-ins Exchange role

### DIFF
--- a/docs/outlook/testing-and-tips.md
+++ b/docs/outlook/testing-and-tips.md
@@ -66,11 +66,11 @@ And, if you do not have at minimum the "My Custom Apps" role for your Exchange S
 
 The Exchange administrator can run the following PowerShell cmdlet to assign a single user the necessary permissions. In this example, wendyri is the user's email alias.
 
-**New-ManagementRoleAssignment -Role "My Custom Apps" -User "wendyri"** 
+```New-ManagementRoleAssignment -Role "My Custom Apps" -User "wendyri"```
 
 If necessary, the administrator can run the following cmdlet to assign multiple users the similar necessary permissions:
 
-**$users = Get-Mailbox *$users | ForEach-Object { New-ManagementRoleAssignment -Role "My Custom Apps" -User $_.Alias}**
+```$users = Get-Mailbox *$users | ForEach-Object { New-ManagementRoleAssignment -Role "My Custom Apps" -User $_.Alias}```
 
 For more information about the My Custom Apps role, see [My Custom Apps role](http://technet.microsoft.com/en-us/library/aa0321b3-2ec0-4694-875b-7a93d3d99089%28EXCHG.150%29.aspx). 
 

--- a/docs/outlook/testing-and-tips.md
+++ b/docs/outlook/testing-and-tips.md
@@ -62,17 +62,17 @@ To use Outlook Web App (OWA) to install an Outlook add-in, follow these steps:
 - Napa Office 365 Development Tools
 - Visual Studio
 
-And, if you do not have at minimum the "My Custom add-ins" role for your Exchange Server, then you can install add-ins only from the Office Store. In order to test your add-in, or install add-ins in general by specifying a URL or file name for the add-in manifest, you should request your Exchange administrator to provide the necessary permissions.
+And, if you do not have at minimum the "My Custom Apps" role for your Exchange Server, then you can install add-ins only from the Office Store. In order to test your add-in, or install add-ins in general by specifying a URL or file name for the add-in manifest, you should request your Exchange administrator to provide the necessary permissions.
 
 The Exchange administrator can run the following PowerShell cmdlet to assign a single user the necessary permissions. In this example, wendyri is the user's email alias.
 
-**New-ManagementRoleAssignment -Role "My Custom add-ins" -User "wendyri"** 
+**New-ManagementRoleAssignment -Role "My Custom Apps" -User "wendyri"** 
 
 If necessary, the administrator can run the following cmdlet to assign multiple users the similar necessary permissions:
 
-**$users = Get-Mailbox *$users | ForEach-Object { New-ManagementRoleAssignment -Role "My Custom add-ins" -User $_.Alias}**
+**$users = Get-Mailbox *$users | ForEach-Object { New-ManagementRoleAssignment -Role "My Custom Apps" -User $_.Alias}**
 
-For more information about the My Custom add-ins role, see [My Custom add-ins role](http://technet.microsoft.com/en-us/library/aa0321b3-2ec0-4694-875b-7a93d3d99089%28EXCHG.150%29.aspx). 
+For more information about the My Custom Apps role, see [My Custom Apps role](http://technet.microsoft.com/en-us/library/aa0321b3-2ec0-4694-875b-7a93d3d99089%28EXCHG.150%29.aspx). 
 
 Using Office 365, Napa, or Visual Studio to develop add-ins assigns you the organization administrator role which allows you to install add-ins by file or URL in the EAC, or by Powershell cmdlets.
 


### PR DESCRIPTION
The add-ins role in Exchange has changed from "My Custom add-ins" to "My Custom
Apps" at some point. The former no longer works.