### PR TITLE
Add OneNote to Manifest documentation

### DIFF
--- a/docs/onenote/onenote-add-ins-getting-started.md
+++ b/docs/onenote/onenote-add-ins-getting-started.md
@@ -68,7 +68,7 @@ You can develop the add-in using any text editor or IDE. If you haven't tried Vi
    b. Replace the script reference to Office.js with the following reference to the *beta* version.
 
 ```
-<script src="https://richapiaddin.azurewebsites.net/App/Office/Office.js"></script>
+<script src="https://appsforoffice.officeapps.live.com/afo/lib/1.1/hosted/office.js"></script>
 ```
 
 Your Office references will look like this.
@@ -76,7 +76,7 @@ Your Office references will look like this.
 ```
 <link href="//appsforoffice.microsoft.com/fabric/1.0/fabric.min.css" rel="stylesheet">
 <link href="//appsforoffice.microsoft.com/fabric/1.0/fabric.components.min.css" rel="stylesheet">
-<script src="https://richapiaddin.azurewebsites.net/App/Office/Office.js"></script>
+<script src="https://appsforoffice.officeapps.live.com/afo/lib/1.1/hosted/office.js"></script>
 ```
 
 3- Replace the `<body>` element with the following code. This adds a text area and a button using [Office UI Fabric components](http://dev.office.com/fabric/components). The **Responsive Grid** layout is from the set of [Office UI Fabric styles](http://dev.office.com/fabric/styles). 

--- a/reference/manifest/extensionpoint.md
+++ b/reference/manifest/extensionpoint.md
@@ -9,7 +9,7 @@
 |  **xsi:type**  |  Yes  | The type of extension point being defined.|
 
 
-## Extension points for Word, Excel, and PowerPoint add-in commands
+## Extension points for Word, Excel, PowerPoint, and OneNote add-in commands
 
 - **PrimaryCommandSurface** - The ribbon in Office.
 - **ContextMenu** - The shortcut menu that appears when you right-click in the Office UI.

--- a/reference/manifest/getstarted.md
+++ b/reference/manifest/getstarted.md
@@ -1,6 +1,6 @@
 # GetStarted element
 
- Provides information used by the callout that appears when the add-in is installed in Word, Excel, and PowerPoint hosts. The **GetStarted** element is a child element of [FormFactor](./formfactor.md).
+Provides information used by the callout that appears when the add-in is installed in Word, Excel, PowerPoint, and OneNote hosts. The **GetStarted** element is a child element of [FormFactor](./formfactor.md).
 
  ## Child elements
 

--- a/reference/manifest/host.md
+++ b/reference/manifest/host.md
@@ -32,6 +32,7 @@ You can specify the following values in the  **Name** attribute of a **Host** el
 | `"Document"`|Word, Word Online, Word on iPad|
 | `"Database"`|Access web apps|
 | `"Mailbox"`|Outlook, Outlook Web App, OWA for Devices|
+| `"Notebook"`|OneNote Online|
 | `"Presentation"`|PowerPoint, PowerPoint Online, PowerPoint on iPad|
 | `"Project"`|Project|
 | `"Workbook"`|Excel, Excel Online, Excel on iPad|

--- a/reference/manifest/hosts.md
+++ b/reference/manifest/hosts.md
@@ -15,7 +15,7 @@ When included in the [VersionOverrides](./versionoverrides.md) node, this elemen
 ---- 
 
 ## Host element
-Specifies an individual Office application type where the add-in should activate, such as “document”, “workbook”, “presentation”, “project”, “mailbox”.
+Specifies an individual Office application type where the add-in should activate, such as “document”, “workbook”, “presentation”, “project”, “mailbox”, and "notebook".
 
 ### Attributes
 
@@ -31,7 +31,7 @@ Specifies an individual Office application type where the add-in should activate
 
 
 ### xsi:type
-Controls which Office host (Word, Excel, PowerPoint, Outlook) the contained settings apply too. The value must be one of the following:
+Controls which Office host (Word, Excel, PowerPoint, Outlook, OneNote) the contained settings apply too. The value must be one of the following:
 
 - `MailHost` (Outlook)    
 

--- a/reference/manifest/officemenu.md
+++ b/reference/manifest/officemenu.md
@@ -1,5 +1,5 @@
 # OfficeMenu element
-Defines a collection of controls to be added to the Office context menu. Applies to Word, Excel, and PowerPoint add-ins.  
+Defines a collection of controls to be added to the Office context menu. Applies to Word, Excel, PowerPoint, and OneNote add-ins.
 
 ## Attributes
 
@@ -15,7 +15,7 @@ Defines a collection of controls to be added to the Office context menu. Applies
 ## xsi:type
 Specifies a built-in menu of the Office client application on which to add this Office Add-in.
 
-- `ContextMenuText` -  Displays the item on the context menu when text is selected and the user opens the context menu (right-clicks) on the selected text. Applies to Word, Excel, and PowerPoint. 
+- `ContextMenuText` -  Displays the item on the context menu when text is selected and the user opens the context menu (right-clicks) on the selected text. Applies to Word, Excel, PowerPoint, and OneNote.
 - `ContextMenuCell` -  Displays the item on the context menu when the user opens the context menu (right-clicks) on a cell on the spreadsheet. Applies to Excel. 
 
 ## Control

--- a/reference/manifest/officetab.md
+++ b/reference/manifest/officetab.md
@@ -66,6 +66,12 @@ The following are valid tab `id` values by host. Values in **bold** are supporte
 - TabBackgroundRemoval
 - TabSlideMasterHome
 
+### OneNote
+- **TabHome**
+- **TabInsert**
+- **TabView**
+- TabDeveloper
+- TabAddIns
 
 ## Group
 A group of UI extension points in a tab. A group can have up to six controls. The  **id** attribute is required and each **id** must be unique within the manifest. The **id** is a string with a maximum of 125 characters. See [Group element](./group.md).


### PR DESCRIPTION
Adds information on OneNote-specific functionality and host types to the Manifest documentation