### PR TITLE
change 2nd parameter of isSetSupported to a number

### DIFF
--- a/reference/shared/officeui.displaydialogasync.md
+++ b/reference/shared/officeui.displaydialogasync.md
@@ -23,7 +23,7 @@ This method is available in the DialogAPI [requirement set](../../docs/overview/
 To detect this API at runtime, use the following code.
 
 ```js
- if (Office.context.requirements.isSetSupported('DialogAPI', '1.1')) 
+ if (Office.context.requirements.isSetSupported('DialogAPI', 1.1)) 
  	{  
     	 // Use Office UI methods; 
  	} 


### PR DESCRIPTION
1.1 needs to be a number, not a "1.1" string.
If there's anywhere else in our documentation where we have this, we should fix it there, too.