### PR TITLE
Fix bad link in defaultsettings.md

### DIFF
--- a/reference/manifest/defaultsettings.md
+++ b/reference/manifest/defaultsettings.md
@@ -26,7 +26,7 @@ Specifies the default source location and other default settings for your conten
 
 |**Element**|**Content**|**Mail**|**TaskPane**|
 |:-----|:-----|:-----|:-----|
-|[SourceLocation](../../reference/manifest/override.md)|x||x|
+|[SourceLocation](../../reference/manifest/sourcelocation.md)|x||x|
 |[RequestedWidth](../../reference/manifest/requestedwidth.md)|x|||
 |[RequestedHeight](../../reference/manifest/requestedheight.md)|x|||
 


### PR DESCRIPTION
The link pointed to override.md instead of sourcelocation.md