### PR TITLE
Update paragraph.md

### DIFF
--- a/reference/word/paragraph.md
+++ b/reference/word/paragraph.md
@@ -350,7 +350,7 @@ Word.run(function (context) {
 The [Word-Add-in-DocumentAssembly][paragraph.insertContentControl] sample shows how you can use the insertContentControl method.
 
 ### insertFileFromBase64(base64File: string, insertLocation: InsertLocation)
-Inserts a document into the current paragraph at the specified location. The insertLocation value can be 'Start' or 'End'.
+Inserts a document into the current paragraph at the specified location. The insertLocation value can be ‘Replace’, 'Start' or 'End'.
 
 #### Syntax
 ```js


### PR DESCRIPTION
Update allowed insertLocation of insertFileFromBase64 in Paragraph.
Add "Replace" in insertLocation because Word online and Word Win32 client support this value.
Editor: Ron Lin (Microsoft FTE and member of Word WAC Rich API Feature Crew)