### PR TITLE
Update paragraph.md

### DIFF
--- a/reference/word/paragraph.md
+++ b/reference/word/paragraph.md
@@ -459,7 +459,7 @@ Word.run(function (context) {
 ```
 
 ### insertInlinePictureFromBase64(base64EncodedImage: string, insertLocation: InsertLocation)
-Inserts a picture into the paragraph at the specified location. The insertLocation value can be 'Before', 'After', 'Start' or 'End'.
+Inserts a picture into the paragraph at the specified location. The insertLocation value can be 'Replace', 'Start' or 'End'.
 
 #### Syntax
 ```js


### PR DESCRIPTION
Update allowed insertLocation of insertInlinePictureFromBase64 in Paragraph.
Add "Replace" in insertLocation because Word online and Word Win32 client support this value.
Remove "Before" & "After" because Word online and Word Win32 client don't support these values.
Editor: Ron Lin (Microsoft FTE and member of Word WAC Rich API Feature Crew)