### PR TITLE
Update range.md

### DIFF
--- a/reference/word/range.md
+++ b/reference/word/range.md
@@ -488,7 +488,7 @@ Word.run(function (context) {
 ```
 
 ### insertText(text: string, insertLocation: InsertLocation)
-Inserts text into the range at the specified location. The insertLocation value can be 'Replace', 'Start' or 'End'.
+Inserts text into the range at the specified location. The insertLocation value can be 'Replace', 'Start', 'End', ‘Before’ or ‘After’.
 
 #### Syntax
 ```js


### PR DESCRIPTION
Update allowed insertLocation of insetText in Range.
Add "Before" & "After" in insertLocation because Word online and Word Win32 client support these values.
Editor: Ron Lin (Microsoft FTE and member of Word WAC Rich API Feature Crew)