### PR TITLE
Update paragraph.md

### DIFF
--- a/reference/word/paragraph.md
+++ b/reference/word/paragraph.md
@@ -361,7 +361,7 @@ paragraphObject.insertFileFromBase64(base64File, insertLocation);
 | Parameter	   | Type	|Description|
 |:---------------|:--------|:----------|
 |base64File|string|Required. The file base64 encoded file contents to be inserted.|
-|insertLocation|InsertLocation|Required. The value can be 'Start' or 'End'.|
+|insertLocation|InsertLocation|Required. The value can be ‘Replace’, 'Start' or 'End'.|
 
 #### Returns
 [Range](range.md)
@@ -470,7 +470,7 @@ paragraphObject.insertInlinePictureFromBase64(base64EncodedImage, insertLocation
 | Parameter	   | Type	|Description|
 |:---------------|:--------|:----------|
 |base64EncodedImage|string|Required. The HTML to be inserted in the paragraph.|
-|insertLocation|InsertLocation|Required. The value can be 'Before', 'After', 'Start', or 'End'.|
+|insertLocation|InsertLocation|Required. The value can be 'Replace', 'Start', or 'End'.|
 
 #### Returns
 [InlinePicture](inlinepicture.md)


### PR DESCRIPTION
Update the table of Parameter:

Update allowed insertLocation of insertFileFromBase64 in Paragraph.
Add "Replace" in insertLocation because Word online and Word Win32 client support this value.

Update allowed insertLocation of insertInlinePictureFromBase64 in Paragraph.
Add "Replace" in insertLocation because Word online and Word Win32 client support this value.
Remove "Before" & "After" because Word online and Word Win32 client don't support these values.

Editor: Ron Lin (Microsoft FTE and member of Word WAC Rich API Feature Crew)