### PR TITLE
Update range.md

### DIFF
--- a/reference/word/range.md
+++ b/reference/word/range.md
@@ -499,7 +499,7 @@ rangeObject.insertText(text, insertLocation);
 | Parameter	   | Type	|Description|
 |:---------------|:--------|:----------|
 |text|string|Required. Text to be inserted.|
-|insertLocation|InsertLocation|Required. The value can be 'Replace', 'Start' or 'End'.|
+|insertLocation|InsertLocation|Required. The value can be 'Replace', 'Start', 'End', ‘Before’ or ‘After’.|
 
 #### Returns
 [Range](range.md)


### PR DESCRIPTION
Update the table of Parameter:
Update allowed insertLocation of insetText in Range.
Add "Before" & "After" in insertLocation because Word online and Word Win32 client support these values.
Editor: Ron Lin (Microsoft FTE and member of Word WAC Rich API Feature Crew)