### PR TITLE
Corrected manifest id

### DIFF
--- a/docs/word/dictionary-task-pane-add-ins.md
+++ b/docs/word/dictionary-task-pane-add-ins.md
@@ -202,7 +202,7 @@ The following is an example manifest file for a dictionary add-in.
 ```XML
 <?xml version="1.0" encoding="utf-8"?>
 <OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TaskPaneApp">
-  <Id>DemoDict</Id>
+  <Id>7164e750-dc86-49c0-b548-1bac57abdc7c</Id>
   <Version>15.0</Version>
   <ProviderName>Microsoft Office Demo Dictionary</ProviderName>
   <DefaultLocale>en-us</DefaultLocale>


### PR DESCRIPTION
Minor fix to change <ID> to a GUID. This topic still needs to be
refreshed as it is using outdated examples.