### PR TITLE
Update troubleshoot-manifest.md

### DIFF
--- a/docs/testing/troubleshoot-manifest.md
+++ b/docs/testing/troubleshoot-manifest.md
@@ -2,22 +2,41 @@
 
 Use these methods to validate and troubleshoot issues in your manifest. 
 
+- [Validate the Office Add-ins manifest with the Office Add-in Validator](validate-the-office-add-ins-manifest-against-validator)
 - [Validate the Office Add-ins manifest against the XML schema](validate-the-office-add-ins-manifest-against-the-xml-schema)
 - [Use runtime logging to debug the manifest for your Office Add-in](use-runtime-logging-to-debug-the-manifest-for-your-office-add-in)
 
+## Validate your manifest with the Office Add-in Validator
+To help to make sure that the manifest file that describes your Office Add-in is correct and complete, validate it against the [Office Add-in Validator](https://github.com/OfficeDev/office-addin-validator).
+
+To use the Office Add-in Validator to validate your manifest:
+1. Install [Node.js](https://nodejs.org/download/) on your machine. 
+2. Open a command prompt / terminal as an administrator, and install the Office Add-in Validator and its dependencies globally by using the following command:
+
+	```
+	npm install -g office-addin-validator
+	```
+	> Note: If you already have Yo Office installed, upgrade to the latest version, and the validator will be installed as a dependency.
+
+3. Run the following command to validate your manifest. Replace MANIFEST.XML with the path to the manifest XML file.
+
+	```
+	validate-office-addin MANIFEST.XML
+	```
+
+
 ## Validate your manifest against the XML schema
 
-To help to make sure that the manifest file that describes your Office Add-in is correct and complete, validate it against the [XML Schema Definition (XSD)](https://github.com/OfficeDev/office-js-docs/tree/master/docs/overview/schemas) files. 
-You can use an XML schema validation tool or [Visual Studio](../get-started/create-and-debug-office-add-ins-in-visual-studio.md) to validate the manifest. 
-
-To use Visual Studio, go to Build > Publish, and choose **Perform Validation check**.
+To help to make sure that the manifest file follows the correct schema, validate it against the [XML Schema Definition (XSD)](https://github.com/OfficeDev/office-js-docs/tree/master/docs/overview/schemas) files. 
+You can use an XML schema validation tool to perform this validation. 
 
 To use a command-line XML schema validation tool to validate your manifest:
 
 1.	Install [tar](https://www.gnu.org/software/tar/) and [libxml](http://xmlsoft.org/FAQ.html), if you haven't already. 
 2.	Run the following command. Replace XSD_FILE with the path to the manifest XSD file and XML_FILE with the path to the manifest XML file.
-
+	```
 	xmllint --noout --schema XSD_FILE XML_FILE
+	```
 
 ## Use runtime logging to debug your add-in manifest
 


### PR DESCRIPTION
Updated this to include information on the Office Add-in Validator. Also, removed Visual Studio from the schema validation section, because this is no longer accurate now that VS pulls from the same validation service as the Office Add-in Validator.

Wasn't 100% sure how to link from the list of methods at the top to the specific section, so I need a bit of assistance there.