### PR TITLE
Document maximum custom property value length

### DIFF
--- a/reference/word/customproperty.md
+++ b/reference/word/customproperty.md
@@ -10,7 +10,7 @@ Represents a custom property.
 |:---------------|:--------|:----------|:----|
 |key|string|Gets the key of the custom property. Read only. Read-only.|[1.3](../requirement-sets/word-api-requirement-sets.md)|
 |[type](enums.md)|string|Gets the value type of the custom property. Read only. Read-only. Possible values are: String, Number, Date, Boolean.|[1.3](../requirement-sets/word-api-requirement-sets.md)|
-|value|object|Gets or sets the value of the custom property.|[1.3](../requirement-sets/word-api-requirement-sets.md)|
+|value|object|Gets or sets the value of the custom property. Note that even though Word Online and the docx file format allow these properties to be arbitrarily long, the desktop version of Word will truncate string values to 255 16-bit chars (possibly creating invalid unicode by breaking up a surrogate pair).|[1.3](../requirement-sets/word-api-requirement-sets.md)|
 
 _See property access [examples.](#property-access-examples)_
 


### PR DESCRIPTION
Custom properties are truncated to 255 16-bit UTF-16 code-units in the desktop edition of Word, while this limitation does not appear to exist in Word Online. This truncation appears to be unicode-unaware: if the 255th character and 256th characters form a surrogate pair, the truncation will truncate so that the value ends with a high surrogate, without the matching low surrogate. This commit documents this surprising behavior.

Having this documented would have saved me a day of my life 😛.