### PR TITLE
Correct method name to Configuration

### DIFF
--- a/docs/develop/create-sso-office-add-ins-aspnet.md
+++ b/docs/develop/create-sso-office-add-ins-aspnet.md
@@ -219,7 +219,7 @@ Here’s an example of what the four keys you changed should look like. *Note th
 
     `public partial class Startup`
 
-1. Add the following line to the body of the `Configure` method. You create the `ConfigureAuth` method in a later step.
+1. Add the following line to the body of the `Configuration` method. You create the `ConfigureAuth` method in a later step.
 
     `ConfigureAuth(app);`
 


### PR DESCRIPTION
Correct method name to Configuration.  Startup class method which needs to be modified was incorrect.