### PR TITLE
new article on Rich API object.set method

### DIFF
--- a/reference/shared/context.md
+++ b/reference/shared/context.md
@@ -22,7 +22,7 @@ Office.context
 |document| [Document object](office.context.document.md)|Gets an object that represents the document the content or task pane add-in is interacting with.|
 |host|string|Contains the host in which the add-in (web application) is running in. Possible values are: Word, Excel, PowerPoint, Outlook, OneNote, Project, Access|
 |officeTheme|[OfficeTheme object](office.context.officetheme.md)|Provides access to the properties for Office theme colors.|
-|platform|string|Provides the platform on which the add-in is running. Possible values are: PC, OfficeOnline, Mac, iOS|
+|platform|string|Provides the platform on which the add-in is running. Possible values are: PC, OfficeOnline, Mac, iOS, Android, Universal|
 |requirements|object|Offers `requirements.isSetSupported()` method to check if the specified requirement set is supported by the host Office application. <br/> `isSetSupported(name: string, minVersion?: number): boolean;` <br> @param name - Set name. e.g.: "MatrixBindings". <br/>|
 |roamingSettings| [RoamingSettings object](office.context.roamingsettings.md)|Gets an object that represents the saved custom settings of the add-in.|
 |touchEnabled|bool|Gets whether the add-in is running in an Office host application that is touch enabled.|
@@ -52,6 +52,7 @@ The  **Context** object provides access to key objects in the JavaScript API for
 
 |**Version**|**Changes**|
 |:-----|:-----|
+|1.1|Added Android and Universal as possible values for the platform property.|
 |1.1|Added  **commerceAllowed** and **touchEnabledAdded** properties (Excel, PowerPoint and Word on Office for iPad only).|
 |1.1|Added support for add-ins with Excel and Word on Office for iPad.|
 |1.1|For [contentLanguage](../../reference/shared/office.context.contentlanguage.md), [displayLanguage](../../reference/shared/office.context.displaylanguage.md), and [document](../../reference/shared/office.context.document.md), added support for content add-ins for Access.|

--- a/reference/shared/hosttype-enumeration.md
+++ b/reference/shared/hosttype-enumeration.md
@@ -1,0 +1,63 @@
+
+# HostType enumeration
+Specifies the host Office application in which the add-in is running.
+
+|||
+|:-----|:-----|
+|**Hosts:**|Excel, Word, PowerPoint, Outlook, OneNote, Project, Access|
+|**Last changed**|1.1|
+
+```js
+Office.HostType
+```
+
+## Members
+
+
+**Values**
+
+
+|**Enumeration**|**Value**|**Description**|
+|:-----|:-----|:-----|
+|Office.HostType.Word|"word"|The Office host is Microsoft Word.|
+|Office.HostType.Excel|"excel"|The Office host is Microsoft Excel.|
+|Office.HostType.PowerPoint|"powerPoint"|The Office host is Microsoft PowerPoint.|
+|Office.HostType.Outlook|"outlook"|The Office host is Microsoft Outlook.|
+|Office.HostType.OneNote|"oneNote"|The Office host is Microsoft OneNote.|
+|Office.HostType.Project|"project"|The Office host is Microsoft Project.|
+|Office.HostType.Access|"access"|The Office host is Microsoft Access.|
+
+
+
+## Support details
+
+
+A capital Y in the following matrix indicates that this enumeration is supported in the corresponding Office host application. An empty cell indicates that the Office host application doesn't support this enumeration.
+
+For more information about Office host application and server requirements, see [Requirements for running Office Add-ins](../../docs/overview/requirements-for-running-office-add-ins.md).
+
+
+**Supported hosts, by platform**
+
+
+||**Office for Windows desktop**|**Office Online (in browser)**|**Office for iPad**|**OWA for Devices**|**Office for Mac**|
+|:-----|:-----|:-----|:-----|:-----|:-----|
+|**Access**|Y|||||
+|**Excel**|Y|Y|Y|||
+|**Outlook**|Y|Y||Y|Y|
+|**PowerPoint**|Y|Y|Y|||
+|**Project**|Y|||||
+|**Word**|Y|Y|Y|||
+
+|||
+|:-----|:-----|
+|**Add-in types**|Content, Outlook (compose mode), task pane|
+|**Library**|Office.js|
+|**Namespace**|Office|
+
+## Support history
+
+
+|**Version**|**Changes**|
+|:-----|:-----|
+|1.1|Introduced|

--- a/reference/shared/platformtype-enumeration.md
+++ b/reference/shared/platformtype-enumeration.md
@@ -1,0 +1,62 @@
+
+# PlatformType enumeration
+Specifies the OS or other platform on which the Office host application is running.
+
+|||
+|:-----|:-----|
+|**Hosts:**|Excel, Word, PowerPoint, Outlook, OneNote, Project, Access|
+|**Last changed**|1.1|
+
+```js
+Office.PlatformType
+```
+
+## Members
+
+
+**Values**
+
+
+|**Enumeration**|**Value**|**Description**|
+|:-----|:-----|:-----|
+|Office.PlatformType.PC|"pc"|The platform is PC (Windows).|
+|Office.PlatformType.OfficeOnline|"officeOnline"|The platform is Office Online.|
+|Office.PlatformType.Mac|"mac"|The platform is Mac.|
+|Office.PlatformType.iOS|"iOS"|The platform an iOS device.|
+|Office.PlatformType.Android|"android"|The platform is an Android device.|
+|Office.PlatformType.Universal|"universal"|The platform is WinRT.|
+
+
+
+## Support details
+
+
+A capital Y in the following matrix indicates that this enumeration is supported in the corresponding Office host application. An empty cell indicates that the Office host application doesn't support this enumeration.
+
+For more information about Office host application and server requirements, see [Requirements for running Office Add-ins](../../docs/overview/requirements-for-running-office-add-ins.md).
+
+
+**Supported hosts, by platform**
+
+
+||**Office for Windows desktop**|**Office Online (in browser)**|**Office for iPad**|**OWA for Devices**|**Office for Mac**|
+|:-----|:-----|:-----|:-----|:-----|:-----|
+|**Access**|Y|||||
+|**Excel**|Y|Y|Y|||
+|**Outlook**|Y|Y||Y|Y|
+|**PowerPoint**|Y|Y|Y|||
+|**Project**|Y|||||
+|**Word**|Y|Y|Y|||
+
+|||
+|:-----|:-----|
+|**Add-in types**|Content, Outlook (compose mode), task pane|
+|**Library**|Office.js|
+|**Namespace**|Office|
+
+## Support history
+
+
+|**Version**|**Changes**|
+|:-----|:-----|
+|1.1|Introduced|

--- a/reference/shared/richapiobject.set.md
+++ b/reference/shared/richapiobject.set.md
@@ -28,7 +28,7 @@ void
 
 #### Examples
 
-Below example sets several format properties with a JavaScript object. 
+The following example sets several format properties with a JavaScript object. 
 
 ```js
 Excel.run(function (ctx) { 
@@ -55,7 +55,7 @@ Excel.run(function (ctx) {
 });
 ```
 
-Below example sets the properties of one range by copying the properties of another range. Note that the source object must be loaded first.
+The following example sets the properties of one range by copying the properties of another range. Note that the source object must be loaded first.
 
 ```js
 Excel.run(function (ctx) { 

--- a/reference/shared/richapiobject.set.md
+++ b/reference/shared/richapiobject.set.md
@@ -1,0 +1,77 @@
+
+
+# Rich API object set method
+Sets multiple properties of an object at once by passing either another object of the same type or a JavaScript object with properties that are structured isomorphically to the properties of the object on which the method is called.
+
+## Method Details
+
+### set(properties: object, options: object)
+The *non-read-only* properties of the object on which the method is called are set to the same values as the corresponding properties of the passed-in object.
+If the `properties` parameter is a JavaScript object, then properties in the passed-in object that correspond to a read-only property in the object on which the method is called are either ignored or cause an exception, depending on the `options` parameter.
+
+#### Syntax
+
+```js
+someRichAPIObject.set(properties[, options]);
+```
+
+#### Parameters
+
+| Parameter	   | Type	|Description|
+|:---------------|:--------|:----------|
+|properties|object|Either an object *of the same Office type* on which the method is called, or a JavaScript object of property names and values that mirrors the structure of the properties of the object type on which the method is called.|
+|options|object|Optional. Can only be passed when the first parameter is a JavaScript object. The object can contain the following property: `throwOnReadOnly?: boolean` (Default is `true`: throw an error if the passed in JavaScript object includes read-only properties.)|
+
+#### Returns
+
+void    
+
+#### Examples
+
+Below example sets several format properties with a JavaScript object. 
+
+```js
+Excel.run(function (ctx) { 
+    var sheet = context.workbook.worksheets.getItem("Sample");
+    var range = sheet.getRange("B2:E2");
+    range.set({
+        format: {
+            fill: {
+                color: '#4472C4'
+            },
+            font: {
+                name: 'Verdana',
+                color: 'white'
+            }
+        }
+    })
+    range.format.autofitColumns();
+	return ctx.sync(); 
+}).catch(function(error) {
+		console.log("Error: " + error);
+		if (error instanceof OfficeExtension.Error) {
+			console.log("Debug info: " + JSON.stringify(error.debugInfo));
+		}
+});
+```
+
+Below example sets the properties of one range by copying the properties of another range. Note that the source object must be loaded first.
+
+```js
+Excel.run(function (ctx) { 
+    var sheet = context.workbook.worksheets.getItem("Sample");
+    var sourceRange = sheet.getRange("B2:E2");
+    sourceRange.load("format/fill/color, format/font/name, format/font/color");
+    return ctx.sync(); 
+
+    var targetRange = sheet.getRange("B7:E7");
+    targetRange.set(sourceRange); 
+    targetRange.format.autofitColumns();
+	return ctx.sync(); 
+}).catch(function(error) {
+		console.log("Error: " + error);
+		if (error instanceof OfficeExtension.Error) {
+			console.log("Debug info: " + JSON.stringify(error.debugInfo));
+		}
+});
+```


### PR DESCRIPTION
This article should NOT be anywhere in the TOC. It will be linked to by various other reference topics.

The articles for the host and platform enums should be in the TOC under https://dev.office.com/reference/add-ins/shared/enumerations
