### PR TITLE
Fixed relative path for Office.context

### DIFF
--- a/reference/outlook/preview/Office.context.md
+++ b/reference/outlook/preview/Office.context.md
@@ -4,7 +4,7 @@
 
 ### [Office](Office.md).context
 
-The Office.context namespace provides shared interfaces that are used by add-ins in all of the Office apps. This listing documents only those interfaces that are used by Outlook add-ins. For a full listing of the Office.context namespace, see the [Office.context reference in the Shared API](../shared/office.context.md).
+The Office.context namespace provides shared interfaces that are used by add-ins in all of the Office apps. This listing documents only those interfaces that are used by Outlook add-ins. For a full listing of the Office.context namespace, see the [Office.context reference in the Shared API](../../shared/office.context.md).
 
 ##### Requirements
 


### PR DESCRIPTION
The relative url in [Office.context](https://dev.office.com/reference/add-ins/outlook/preview/Office.context) for [Shared API](https://dev.office.com/reference/add-ins/shared/office.context) was broken.