### PR TITLE
cell -> getCell

### DIFF
--- a/reference/excel/range.md
+++ b/reference/excel/range.md
@@ -216,7 +216,7 @@ Excel.run(function (ctx) {
 	var rangeAddress = "A1:F8";
 	var worksheet = ctx.workbook.worksheets.getItem(sheetName);
 	var range = worksheet.getRange(rangeAddress);
-	var cell = range.cell(0,0);
+	var cell = range.getCell(0,0);
 	cell.load('address');
 	return ctx.sync().then(function() {
 		console.log(cell.address);


### PR DESCRIPTION
Is this wrong?

If not, `cell` is missing in properties in this doc:
https://github.com/OfficeDev/office-js-docs/blob/master/reference/excel/range.md#properties