### PR TITLE
Outlook ref updates (#1276)

### DIFF
--- a/reference/outlook/1.1/Office.context.mailbox.item.md
+++ b/reference/outlook/1.1/Office.context.mailbox.item.md
@@ -76,7 +76,7 @@ if (_Item.attachments.length > 0) {
 
 ####  bcc :[Recipients](Recipients.md)
 
-Gets or sets the recipients on the Bcc (blind carbon copy) line of a message. Compose mode only.
+Gets an object that provides methods to get or update the recipients on the Bcc (blind carbon copy) line of a message. Compose mode only.
 
 ##### Type:
 
@@ -94,6 +94,7 @@ Gets or sets the recipients on the Bcc (blind carbon copy) line of a message. Co
 
 ```JavaScript
 Office.context.mailbox.item.bcc.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.bcc.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.bcc.getAsync(callback);
 
 function callback(asyncResult) {
@@ -118,7 +119,7 @@ Gets an object that provides methods for manipulating the body of an item.
 |Applicable Outlook mode| Compose or read|
 ####  cc :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets the Cc (carbon copy) recipients of a message.
+Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -126,7 +127,7 @@ The `cc` property returns an array that contains an `EmailAddressDetails` object
 
 ##### Compose mode
 
-The `cc` property returns a `Recipients` object that provides methods for manipulating the recipients on the **Cc** line of the message.
+The `cc` property returns a `Recipients` object that provides methods to get or update the recipients on the **Cc** line of the message.
 
 ##### Type:
 
@@ -144,6 +145,7 @@ The `cc` property returns a `Recipients` object that provides methods for manipu
 
 ```JavaScript
 Office.context.mailbox.item.cc.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.cc.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.cc.getAsync(callback);
 
 function callback(asyncResult) {
@@ -459,7 +461,7 @@ var normalizedSubject = Office.context.mailbox.item.normalizedSubject;
 
 ####  optionalAttendees :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets a list of email addresses for optional attendees.
+Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -467,7 +469,7 @@ The `optionalAttendees` property returns an array that contains an `EmailAddress
 
 ##### Compose mode
 
-The `optionalAttendees` property returns a `Recipients` object that provides methods to get and set the optional attendees for a meeting.
+The `optionalAttendees` property returns a `Recipients` object that provides methods to get or update the optional attendees for a meeting.
 
 ##### Type:
 
@@ -485,6 +487,7 @@ The `optionalAttendees` property returns a `Recipients` object that provides met
 
 ```JavaScript
 Office.context.mailbox.item.optionalAttendees.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.optionalAttendees.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.optionalAttendees.getAsync(callback);
 
 function callback(asyncResult) {
@@ -517,7 +520,7 @@ var organizerAddress = Office.context.mailbox.item.organizer.emailAddress;
 
 ####  requiredAttendees :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets a list of email addresses for required attendees.
+Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -525,7 +528,7 @@ The `requiredAttendees` property returns an array that contains an `EmailAddress
 
 ##### Compose mode
 
-The `requiredAttendees` property returns a `Recipients` object that provides methods to get and set the required attendees for a meeting.
+The `requiredAttendees` property returns a `Recipients` object that provides methods to get or update the required attendees for a meeting.
 
 ##### Type:
 
@@ -543,6 +546,7 @@ The `requiredAttendees` property returns a `Recipients` object that provides met
 
 ```JavaScript
 Office.context.mailbox.item.requiredAttendees.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.requiredAttendees.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.requiredAttendees.getAsync(callback);
 
 function callback(asyncResult) {
@@ -680,9 +684,10 @@ function callback(asyncResult) {
 |[Minimum mailbox requirement set version](../tutorial-api-requirement-sets.md)| 1.0|
 |[Minimum permission level](../../../docs/outlook/understanding-outlook-add-in-permissions.md)| ReadItem|
 |Applicable Outlook mode| Compose or read|
+
 ####  to :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets the recipients of an email message.
+Provides access to the recipients on the **To** line of a message. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -690,7 +695,7 @@ The `to` property returns an array that contains an `EmailAddressDetails` object
 
 ##### Compose mode
 
-The `to` property returns a `Recipients` object that provides methods for manipulating the recipients on the **To** line of the message.
+The `to` property returns a `Recipients` object that provides methods to get or update the recipients on the **To** line of the message.
 
 ##### Type:
 
@@ -708,6 +713,7 @@ The `to` property returns a `Recipients` object that provides methods for manipu
 
 ```JavaScript
 Office.context.mailbox.item.to.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.to.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.to.getAsync(callback);
 
 function callback(asyncResult) {

--- a/reference/outlook/1.2/Office.context.mailbox.item.md
+++ b/reference/outlook/1.2/Office.context.mailbox.item.md
@@ -76,7 +76,7 @@ if (_Item.attachments.length > 0) {
 
 ####  bcc :[Recipients](Recipients.md)
 
-Gets or sets the recipients on the Bcc (blind carbon copy) line of a message. Compose mode only.
+Gets an object that provides methods to get or update the recipients on the Bcc (blind carbon copy) line of a message. Compose mode only.
 
 ##### Type:
 
@@ -94,6 +94,7 @@ Gets or sets the recipients on the Bcc (blind carbon copy) line of a message. Co
 
 ```JavaScript
 Office.context.mailbox.item.bcc.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.bcc.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.bcc.getAsync(callback);
 
 function callback(asyncResult) {
@@ -118,7 +119,7 @@ Gets an object that provides methods for manipulating the body of an item.
 |Applicable Outlook mode| Compose or read|
 ####  cc :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets the Cc (carbon copy) recipients of a message.
+Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -126,7 +127,7 @@ The `cc` property returns an array that contains an `EmailAddressDetails` object
 
 ##### Compose mode
 
-The `cc` property returns a `Recipients` object that provides methods for manipulating the recipients on the **Cc** line of the message.
+The `cc` property returns a `Recipients` object that provides methods to get or update the recipients on the **Cc** line of the message.
 
 ##### Type:
 
@@ -144,6 +145,7 @@ The `cc` property returns a `Recipients` object that provides methods for manipu
 
 ```JavaScript
 Office.context.mailbox.item.cc.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.cc.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.cc.getAsync(callback);
 
 function callback(asyncResult) {
@@ -459,7 +461,7 @@ var normalizedSubject = Office.context.mailbox.item.normalizedSubject;
 
 ####  optionalAttendees :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets a list of email addresses for optional attendees.
+Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -467,7 +469,7 @@ The `optionalAttendees` property returns an array that contains an `EmailAddress
 
 ##### Compose mode
 
-The `optionalAttendees` property returns a `Recipients` object that provides methods to get and set the optional attendees for a meeting.
+The `optionalAttendees` property returns a `Recipients` object that provides methods to get or update the optional attendees for a meeting.
 
 ##### Type:
 
@@ -485,6 +487,7 @@ The `optionalAttendees` property returns a `Recipients` object that provides met
 
 ```JavaScript
 Office.context.mailbox.item.optionalAttendees.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.optionalAttendees.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.optionalAttendees.getAsync(callback);
 
 function callback(asyncResult) {
@@ -517,7 +520,7 @@ var organizerAddress = Office.context.mailbox.item.organizer.emailAddress;
 
 ####  requiredAttendees :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets a list of email addresses for required attendees.
+Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -525,7 +528,7 @@ The `requiredAttendees` property returns an array that contains an `EmailAddress
 
 ##### Compose mode
 
-The `requiredAttendees` property returns a `Recipients` object that provides methods to get and set the required attendees for a meeting.
+The `requiredAttendees` property returns a `Recipients` object that provides methods to get or update the required attendees for a meeting.
 
 ##### Type:
 
@@ -543,6 +546,7 @@ The `requiredAttendees` property returns a `Recipients` object that provides met
 
 ```JavaScript
 Office.context.mailbox.item.requiredAttendees.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.requiredAttendees.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.requiredAttendees.getAsync(callback);
 
 function callback(asyncResult) {
@@ -680,9 +684,10 @@ function callback(asyncResult) {
 |[Minimum mailbox requirement set version](../tutorial-api-requirement-sets.md)| 1.0|
 |[Minimum permission level](../../../docs/outlook/understanding-outlook-add-in-permissions.md)| ReadItem|
 |Applicable Outlook mode| Compose or read|
+
 ####  to :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets the recipients of an email message.
+Provides access to the recipients on the **To** line of a message. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -690,7 +695,7 @@ The `to` property returns an array that contains an `EmailAddressDetails` object
 
 ##### Compose mode
 
-The `to` property returns a `Recipients` object that provides methods for manipulating the recipients on the **To** line of the message.
+The `to` property returns a `Recipients` object that provides methods to get or update the recipients on the **To** line of the message.
 
 ##### Type:
 
@@ -708,6 +713,7 @@ The `to` property returns a `Recipients` object that provides methods for manipu
 
 ```JavaScript
 Office.context.mailbox.item.to.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.to.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.to.getAsync(callback);
 
 function callback(asyncResult) {

--- a/reference/outlook/1.3/Office.context.mailbox.item.md
+++ b/reference/outlook/1.3/Office.context.mailbox.item.md
@@ -76,7 +76,7 @@ if (_Item.attachments.length > 0) {
 
 ####  bcc :[Recipients](Recipients.md)
 
-Gets or sets the recipients on the Bcc (blind carbon copy) line of a message. Compose mode only.
+Gets an object that provides methods to get or update the recipients on the Bcc (blind carbon copy) line of a message. Compose mode only.
 
 ##### Type:
 
@@ -94,6 +94,7 @@ Gets or sets the recipients on the Bcc (blind carbon copy) line of a message. Co
 
 ```
 Office.context.mailbox.item.bcc.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.bcc.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.bcc.getAsync(callback);
 
 function callback(asyncResult) {
@@ -118,7 +119,7 @@ Gets an object that provides methods for manipulating the body of an item.
 |Applicable Outlook mode| Compose or read|
 ####  cc :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets the Cc (carbon copy) recipients of a message.
+Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -126,7 +127,7 @@ The `cc` property returns an array that contains an `EmailAddressDetails` object
 
 ##### Compose mode
 
-The `cc` property returns a `Recipients` object that provides methods for manipulating the recipients on the **Cc** line of the message.
+The `cc` property returns a `Recipients` object that provides methods to get or update the recipients on the **Cc** line of the message.
 
 ##### Type:
 
@@ -144,6 +145,7 @@ The `cc` property returns a `Recipients` object that provides methods for manipu
 
 ```
 Office.context.mailbox.item.cc.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.cc.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.cc.getAsync(callback);
 
 function callback(asyncResult) {
@@ -472,9 +474,10 @@ Gets the notification messages for an item.
 |[Minimum mailbox requirement set version](../tutorial-api-requirement-sets.md)| 1.3|
 |[Minimum permission level](../../../docs/outlook/understanding-outlook-add-in-permissions.md)| ReadItem|
 |Applicable Outlook mode| Compose or read|
-|[Recipients](Recipients.md)|
-####  optionalAttendees :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>
-Gets or sets a list of email addresses for optional attendees.
+
+####  optionalAttendees :Array.<[EmailAddressDetails]|[Recipients](Recipients.md)|(simple-types.md#emailaddressdetails)>
+
+Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -482,7 +485,7 @@ The `optionalAttendees` property returns an array that contains an `EmailAddress
 
 ##### Compose mode
 
-The `optionalAttendees` property returns a `Recipients` object that provides methods to get and set the optional attendees for a meeting.
+The `optionalAttendees` property returns a `Recipients` object that provides methods to get or update the optional attendees for a meeting.
 
 ##### Type:
 
@@ -500,6 +503,7 @@ The `optionalAttendees` property returns a `Recipients` object that provides met
 
 ```
 Office.context.mailbox.item.optionalAttendees.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.optionalAttendees.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.optionalAttendees.getAsync(callback);
 
 function callback(asyncResult) {
@@ -532,7 +536,7 @@ var organizerAddress = Office.context.mailbox.item.organizer.emailAddress;
 
 ####  requiredAttendees :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets a list of email addresses for required attendees.
+Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -540,7 +544,7 @@ The `requiredAttendees` property returns an array that contains an `EmailAddress
 
 ##### Compose mode
 
-The `requiredAttendees` property returns a `Recipients` object that provides methods to get and set the required attendees for a meeting.
+The `requiredAttendees` property returns a `Recipients` object that provides methods to get or update the required attendees for a meeting.
 
 ##### Type:
 
@@ -558,6 +562,7 @@ The `requiredAttendees` property returns a `Recipients` object that provides met
 
 ```
 Office.context.mailbox.item.requiredAttendees.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.requiredAttendees.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.requiredAttendees.getAsync(callback);
 
 function callback(asyncResult) {
@@ -695,9 +700,10 @@ function callback(asyncResult) {
 |[Minimum mailbox requirement set version](../tutorial-api-requirement-sets.md)| 1.0|
 |[Minimum permission level](../../../docs/outlook/understanding-outlook-add-in-permissions.md)| ReadItem|
 |Applicable Outlook mode| Compose or read|
+
 ####  to :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets the recipients of an email message.
+Provides access to the recipients on the **To** line of a message. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -705,7 +711,7 @@ The `to` property returns an array that contains an `EmailAddressDetails` object
 
 ##### Compose mode
 
-The `to` property returns a `Recipients` object that provides methods for manipulating the recipients on the **To** line of the message.
+The `to` property returns a `Recipients` object that provides methods to get or update the recipients on the **To** line of the message.
 
 ##### Type:
 
@@ -723,6 +729,7 @@ The `to` property returns a `Recipients` object that provides methods for manipu
 
 ```
 Office.context.mailbox.item.to.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.to.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.to.getAsync(callback);
 
 function callback(asyncResult) {

--- a/reference/outlook/1.4/Office.context.mailbox.item.md
+++ b/reference/outlook/1.4/Office.context.mailbox.item.md
@@ -76,7 +76,7 @@ if (_Item.attachments.length > 0) {
 
 ####  bcc :[Recipients](Recipients.md)
 
-Gets or sets the recipients on the Bcc (blind carbon copy) line of a message. Compose mode only.
+Gets an object that provides methods to get or update the Bcc (blind carbon copy) line of a message. Compose mode only.
 
 ##### Type:
 
@@ -94,6 +94,7 @@ Gets or sets the recipients on the Bcc (blind carbon copy) line of a message. Co
 
 ```
 Office.context.mailbox.item.bcc.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.bcc.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.bcc.getAsync(callback);
 
 function callback(asyncResult) {
@@ -118,7 +119,7 @@ Gets an object that provides methods for manipulating the body of an item.
 |Applicable Outlook mode| Compose or read|
 ####  cc :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets the Cc (carbon copy) recipients of a message.
+Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -126,7 +127,7 @@ The `cc` property returns an array that contains an `EmailAddressDetails` object
 
 ##### Compose mode
 
-The `cc` property returns a `Recipients` object that provides methods for manipulating the recipients on the **Cc** line of the message.
+The `cc` property returns a `Recipients` object that provides methods to get or update the recipients on the **Cc** line of the message.
 
 ##### Type:
 
@@ -144,6 +145,7 @@ The `cc` property returns a `Recipients` object that provides methods for manipu
 
 ```
 Office.context.mailbox.item.cc.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.cc.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.cc.getAsync(callback);
 
 function callback(asyncResult) {
@@ -472,9 +474,10 @@ Gets the notification messages for an item.
 |[Minimum mailbox requirement set version](../tutorial-api-requirement-sets.md)| 1.3|
 |[Minimum permission level](../../../docs/outlook/understanding-outlook-add-in-permissions.md)| ReadItem|
 |Applicable Outlook mode| Compose or read|
-|[Recipients](Recipients.md)|
-####  optionalAttendees :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>
-Gets or sets a list of email addresses for optional attendees.
+
+####  optionalAttendees :Array.<[EmailAddressDetails]|[Recipients](Recipients.md)|(simple-types.md#emailaddressdetails)>
+
+Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -482,7 +485,7 @@ The `optionalAttendees` property returns an array that contains an `EmailAddress
 
 ##### Compose mode
 
-The `optionalAttendees` property returns a `Recipients` object that provides methods to get and set the optional attendees for a meeting.
+The `optionalAttendees` property returns a `Recipients` object that provides methods to get or update the optional attendees for a meeting.
 
 ##### Type:
 
@@ -500,6 +503,7 @@ The `optionalAttendees` property returns a `Recipients` object that provides met
 
 ```
 Office.context.mailbox.item.optionalAttendees.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.optionalAttendees.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.optionalAttendees.getAsync(callback);
 
 function callback(asyncResult) {
@@ -532,7 +536,7 @@ var organizerAddress = Office.context.mailbox.item.organizer.emailAddress;
 
 ####  requiredAttendees :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets a list of email addresses for required attendees.
+Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -540,7 +544,7 @@ The `requiredAttendees` property returns an array that contains an `EmailAddress
 
 ##### Compose mode
 
-The `requiredAttendees` property returns a `Recipients` object that provides methods to get and set the required attendees for a meeting.
+The `requiredAttendees` property returns a `Recipients` object that provides methods to get or update the required attendees for a meeting.
 
 ##### Type:
 
@@ -558,6 +562,7 @@ The `requiredAttendees` property returns a `Recipients` object that provides met
 
 ```
 Office.context.mailbox.item.requiredAttendees.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.requiredAttendees.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.requiredAttendees.getAsync(callback);
 
 function callback(asyncResult) {
@@ -697,7 +702,7 @@ function callback(asyncResult) {
 |Applicable Outlook mode| Compose or read|
 ####  to :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets the recipients of an email message.
+Provides access to the recipients on the **To** line of a message. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -705,7 +710,7 @@ The `to` property returns an array that contains an `EmailAddressDetails` object
 
 ##### Compose mode
 
-The `to` property returns a `Recipients` object that provides methods for manipulating the recipients on the **To** line of the message.
+The `to` property returns a `Recipients` object that provides methods to get or update the recipients on the **To** line of the message.
 
 ##### Type:
 
@@ -723,6 +728,7 @@ The `to` property returns a `Recipients` object that provides methods for manipu
 
 ```
 Office.context.mailbox.item.to.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.to.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.to.getAsync(callback);
 
 function callback(asyncResult) {

--- a/reference/outlook/1.5/Office.context.mailbox.item.md
+++ b/reference/outlook/1.5/Office.context.mailbox.item.md
@@ -32,7 +32,7 @@ The `item` namespace is used to access the currently selected message, meeting r
 | [location](#location-stringlocation) | Member |
 | [normalizedSubject](#normalizedsubject-string) | Member |
 | [notificationMessages](#notificationmessages-notificationmessages) | Member |
-| [optionalAttendees](#optionalattendees-arrayemailaddressdetails) | Member |
+| [optionalAttendees](#optionalattendees-arrayemailaddressdetailsrecipients) | Member |
 | [organizer](#organizer-emailaddressdetails) | Member |
 | [requiredAttendees](#requiredattendees-arrayemailaddressdetailsrecipients) | Member |
 | [resources](#resources-emailaddressdetails) | Member |
@@ -118,7 +118,7 @@ if (_Item.attachments.length > 0) {
 
 ####  bcc :[Recipients](Recipients.md)
 
-Gets or sets the recipients on the Bcc (blind carbon copy) line of a message. Compose mode only.
+Gets an object that provides methods to get or update the recipients on the Bcc (blind carbon copy) line of a message. Compose mode only.
 
 ##### Type:
 
@@ -136,6 +136,7 @@ Gets or sets the recipients on the Bcc (blind carbon copy) line of a message. Co
 
 ```
 Office.context.mailbox.item.bcc.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.bcc.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.bcc.getAsync(callback);
 
 function callback(asyncResult) {
@@ -160,7 +161,7 @@ Gets an object that provides methods for manipulating the body of an item.
 |Applicable Outlook mode| Compose or read|
 ####  cc :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets the Cc (carbon copy) recipients of a message.
+Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -168,7 +169,7 @@ The `cc` property returns an array that contains an `EmailAddressDetails` object
 
 ##### Compose mode
 
-The `cc` property returns a `Recipients` object that provides methods for manipulating the recipients on the **Cc** line of the message.
+The `cc` property returns a `Recipients` object that provides methods to get or update the recipients on the **Cc** line of the message.
 
 ##### Type:
 
@@ -186,6 +187,7 @@ The `cc` property returns a `Recipients` object that provides methods for manipu
 
 ```
 Office.context.mailbox.item.cc.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.cc.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.cc.getAsync(callback);
 
 function callback(asyncResult) {
@@ -514,9 +516,10 @@ Gets the notification messages for an item.
 |[Minimum mailbox requirement set version](../tutorial-api-requirement-sets.md)| 1.3|
 |[Minimum permission level](../../../docs/outlook/understanding-outlook-add-in-permissions.md)| ReadItem|
 |Applicable Outlook mode| Compose or read|
-|[Recipients](Recipients.md)|
-####  optionalAttendees :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>
-Gets or sets a list of email addresses for optional attendees.
+
+####  optionalAttendees :Array.<[EmailAddressDetails]|[Recipients](Recipients.md)|(simple-types.md#emailaddressdetails)>
+
+Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -524,7 +527,7 @@ The `optionalAttendees` property returns an array that contains an `EmailAddress
 
 ##### Compose mode
 
-The `optionalAttendees` property returns a `Recipients` object that provides methods to get and set the optional attendees for a meeting.
+The `optionalAttendees` property returns a `Recipients` object that provides methods to get or update the optional attendees for a meeting.
 
 ##### Type:
 
@@ -542,6 +545,7 @@ The `optionalAttendees` property returns a `Recipients` object that provides met
 
 ```
 Office.context.mailbox.item.optionalAttendees.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.optionalAttendees.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.optionalAttendees.getAsync(callback);
 
 function callback(asyncResult) {
@@ -574,7 +578,7 @@ var organizerAddress = Office.context.mailbox.item.organizer.emailAddress;
 
 ####  requiredAttendees :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets a list of email addresses for required attendees.
+Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -582,7 +586,7 @@ The `requiredAttendees` property returns an array that contains an `EmailAddress
 
 ##### Compose mode
 
-The `requiredAttendees` property returns a `Recipients` object that provides methods to get and set the required attendees for a meeting.
+The `requiredAttendees` property returns a `Recipients` object that provides methods to get or update the required attendees for a meeting.
 
 ##### Type:
 
@@ -600,6 +604,7 @@ The `requiredAttendees` property returns a `Recipients` object that provides met
 
 ```
 Office.context.mailbox.item.requiredAttendees.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.requiredAttendees.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.requiredAttendees.getAsync(callback);
 
 function callback(asyncResult) {
@@ -739,7 +744,7 @@ function callback(asyncResult) {
 |Applicable Outlook mode| Compose or read|
 ####  to :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets the recipients of an email message.
+Provides access to the recipients on the **To** line of a message. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -747,7 +752,7 @@ The `to` property returns an array that contains an `EmailAddressDetails` object
 
 ##### Compose mode
 
-The `to` property returns a `Recipients` object that provides methods for manipulating the recipients on the **To** line of the message.
+The `to` property returns a `Recipients` object that provides methods to get or update the recipients on the **To** line of the message.
 
 ##### Type:
 
@@ -765,6 +770,7 @@ The `to` property returns a `Recipients` object that provides methods for manipu
 
 ```
 Office.context.mailbox.item.to.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.to.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.to.getAsync(callback);
 
 function callback(asyncResult) {

--- a/reference/outlook/preview/Office.MailboxEnums.md
+++ b/reference/outlook/preview/Office.MailboxEnums.md
@@ -29,6 +29,7 @@ AttachmentType
 |---|---|---|---|
 |`File`| String|`file`|The attachment is a file.|
 |`Item`| String|`item`|The attachment is an Exchange item.|
+|`Cloud`| String|`cloud`|The attachment is stored in a cloud location, such as OneDrive. The `id` property of the attachment contains a URL to the file.|
 
 ##### Requirements
 

--- a/reference/outlook/preview/Office.context.mailbox.item.md
+++ b/reference/outlook/preview/Office.context.mailbox.item.md
@@ -76,7 +76,7 @@ if (_Item.attachments.length > 0) {
 
 ####  bcc :[Recipients](Recipients.md)
 
-Gets or sets the recipients on the Bcc (blind carbon copy) line of a message. Compose mode only.
+Gets an object that provides methods to get or update the recipients on the Bcc (blind carbon copy) line of a message. Compose mode only.
 
 ##### Type:
 
@@ -94,6 +94,7 @@ Gets or sets the recipients on the Bcc (blind carbon copy) line of a message. Co
 
 ```
 Office.context.mailbox.item.bcc.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.bcc.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.bcc.getAsync(callback);
 
 function callback(asyncResult) {
@@ -118,7 +119,7 @@ Gets an object that provides methods for manipulating the body of an item.
 |Applicable Outlook mode| Compose or read|
 ####  cc :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets the Cc (carbon copy) recipients of a message.
+Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -126,7 +127,7 @@ The `cc` property returns an array that contains an `EmailAddressDetails` object
 
 ##### Compose mode
 
-The `cc` property returns a `Recipients` object that provides methods for manipulating the recipients on the **Cc** line of the message.
+The `cc` property returns a `Recipients` object that provides methods to get or update the recipients on the **Cc** line of the message.
 
 ##### Type:
 
@@ -144,6 +145,7 @@ The `cc` property returns a `Recipients` object that provides methods for manipu
 
 ```
 Office.context.mailbox.item.cc.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.cc.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.cc.getAsync(callback);
 
 function callback(asyncResult) {
@@ -472,9 +474,10 @@ Gets the notification messages for an item.
 |[Minimum mailbox requirement set version](../tutorial-api-requirement-sets.md)| 1.3|
 |[Minimum permission level](../../../docs/outlook/understanding-outlook-add-in-permissions.md)| ReadItem|
 |Applicable Outlook mode| Compose or read|
-|[Recipients](Recipients.md)|
-####  optionalAttendees :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>
-Gets or sets a list of email addresses for optional attendees.
+
+####  optionalAttendees :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)|
+
+Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -482,7 +485,7 @@ The `optionalAttendees` property returns an array that contains an `EmailAddress
 
 ##### Compose mode
 
-The `optionalAttendees` property returns a `Recipients` object that provides methods to get and set the optional attendees for a meeting.
+The `optionalAttendees` property returns a `Recipients` object that provides methods to get or update the optional attendees for a meeting.
 
 ##### Type:
 
@@ -500,6 +503,7 @@ The `optionalAttendees` property returns a `Recipients` object that provides met
 
 ```
 Office.context.mailbox.item.optionalAttendees.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.optionalAttendees.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.optionalAttendees.getAsync(callback);
 
 function callback(asyncResult) {
@@ -532,7 +536,7 @@ var organizerAddress = Office.context.mailbox.item.organizer.emailAddress;
 
 ####  requiredAttendees :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets a list of email addresses for required attendees.
+Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -540,7 +544,7 @@ The `requiredAttendees` property returns an array that contains an `EmailAddress
 
 ##### Compose mode
 
-The `requiredAttendees` property returns a `Recipients` object that provides methods to get and set the required attendees for a meeting.
+The `requiredAttendees` property returns a `Recipients` object that provides methods to get or update the required attendees for a meeting.
 
 ##### Type:
 
@@ -558,6 +562,7 @@ The `requiredAttendees` property returns a `Recipients` object that provides met
 
 ```
 Office.context.mailbox.item.requiredAttendees.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.requiredAttendees.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.requiredAttendees.getAsync(callback);
 
 function callback(asyncResult) {
@@ -695,9 +700,10 @@ function callback(asyncResult) {
 |[Minimum mailbox requirement set version](../tutorial-api-requirement-sets.md)| 1.0|
 |[Minimum permission level](../../../docs/outlook/understanding-outlook-add-in-permissions.md)| ReadItem|
 |Applicable Outlook mode| Compose or read|
+
 ####  to :Array.<[EmailAddressDetails](simple-types.md#emailaddressdetails)>|[Recipients](Recipients.md)
 
-Gets or sets the recipients of an email message.
+Provides access to the recipients on the **To** line of a message. The type of object and level of access depends on the mode of the current item.
 
 ##### Read mode
 
@@ -705,7 +711,7 @@ The `to` property returns an array that contains an `EmailAddressDetails` object
 
 ##### Compose mode
 
-The `to` property returns a `Recipients` object that provides methods for manipulating the recipients on the **To** line of the message.
+The `to` property returns a `Recipients` object that provides methods to get or update the recipients on the **To** line of the message.
 
 ##### Type:
 
@@ -723,6 +729,7 @@ The `to` property returns a `Recipients` object that provides methods for manipu
 
 ```
 Office.context.mailbox.item.to.setAsync( ['alice@contoso.com', 'bob@contoso.com'] );
+Office.context.mailbox.item.to.addAsync( ['jason@contoso.com'] );
 Office.context.mailbox.item.to.getAsync(callback);
 
 function callback(asyncResult) {


### PR DESCRIPTION
* Adding Outlook version to note

* Updated closeContainer doc to indicate only Outlook supports it

* Added 1.5 to Mac Outlook

* Added displayNewMessageForm to preview requirement set for Outlook

* Removed extra column from attachment row in parameter table

* Revert "Removed extra column from attachment row in parameter table"

This reverts commit b7823d1d9488172c01b7d051b8ced03005fe2f6c.

* Removed extra column from parameter table entry

* Fixed descriptions in displayNewMessageForm parameters

* Fixing table formatting

Empty cells on ends of rows

* Added link to Outlook add-in commands doc

* Added Outlook mobile versions to requirement set table

* Added notes about Outlook on the web and appointment compose scenario

Outlook on the web behaves differently for `saveAsync` and `close`.

* Fixed typo in example

* Added cloud attachment type

* Updated docs for Recipients-type members

Updated descriptions to be more consistent and added `addAsync` examples.