### PR TITLE
Office.context.mailbox.diagnostics.hostName does not output `Mac Outlook` 

### DIFF
--- a/reference/outlook/1.1/Office.context.mailbox.diagnostics.md
+++ b/reference/outlook/1.1/Office.context.mailbox.diagnostics.md
@@ -20,7 +20,7 @@ Provides diagnostic information to an Outlook add-in.
 
 Gets a string that represents the name of the host application.
 
-A string that can be one of the following values: `Outlook`, `Mac Outlook`, `OutlookIOS`, or `OutlookWebApp`.
+A string that can be one of the following values: `Outlook`, `OutlookIOS`, or `OutlookWebApp`.
 
 ##### Type:
 

--- a/reference/outlook/1.2/Office.context.mailbox.diagnostics.md
+++ b/reference/outlook/1.2/Office.context.mailbox.diagnostics.md
@@ -20,7 +20,7 @@ Provides diagnostic information to an Outlook add-in.
 
 Gets a string that represents the name of the host application.
 
-A string that can be one of the following values: `Outlook`, `Mac Outlook`, `OutlookIOS`, or `OutlookWebApp`.
+A string that can be one of the following values: `Outlook`, `OutlookIOS`, or `OutlookWebApp`.
 
 ##### Type:
 

--- a/reference/outlook/1.3/Office.context.mailbox.diagnostics.md
+++ b/reference/outlook/1.3/Office.context.mailbox.diagnostics.md
@@ -20,7 +20,7 @@ Provides diagnostic information to an Outlook add-in.
 
 Gets a string that represents the name of the host application.
 
-A string that can be one of the following values: `Outlook`, `Mac Outlook`, `OutlookIOS`, or `OutlookWebApp`.
+A string that can be one of the following values: `Outlook`, `OutlookIOS`, or `OutlookWebApp`.
 
 ##### Type:
 

--- a/reference/outlook/1.4/Office.context.mailbox.diagnostics.md
+++ b/reference/outlook/1.4/Office.context.mailbox.diagnostics.md
@@ -20,7 +20,7 @@ Provides diagnostic information to an Outlook add-in.
 
 Gets a string that represents the name of the host application.
 
-A string that can be one of the following values: `Outlook`, `Mac Outlook`, `OutlookIOS`, or `OutlookWebApp`.
+A string that can be one of the following values: `Outlook`, `OutlookIOS`, or `OutlookWebApp`.
 
 ##### Type:
 

--- a/reference/outlook/1.5/Office.context.mailbox.diagnostics.md
+++ b/reference/outlook/1.5/Office.context.mailbox.diagnostics.md
@@ -26,7 +26,7 @@ Provides diagnostic information to an Outlook add-in.
 
 Gets a string that represents the name of the host application.
 
-A string that can be one of the following values: `Outlook`, `Mac Outlook`, `OutlookIOS`, or `OutlookWebApp`.
+A string that can be one of the following values: `Outlook`, `OutlookIOS`, or `OutlookWebApp`.
 
 ##### Type:
 


### PR DESCRIPTION
The value of `hostName` does not produce `Mac Outlook` for Outlook on a Mac, instead it produces `Outlook`.