### PR TITLE
Fix Outlook RequirementSet Example

### DIFF
--- a/reference/outlook/tutorial-api-requirement-sets.md
+++ b/reference/outlook/tutorial-api-requirement-sets.md
@@ -9,7 +9,7 @@ For example, the following manifest snippet indicates a minimum requirement set 
 ```xml
 <Requirements>
   <Sets>
-    <Set Name="MailBox" MinVersion="1.1" />
+    <Set Name="Mailbox" MinVersion="1.1" />
   </Sets>
 </Requirements>
 ```


### PR DESCRIPTION
Requirement set is called "Mailbox" but in the example it is called "MailBox" which does not seem to work