### PR TITLE
Fixed incorrect sample code

### DIFF
--- a/reference/excel/worksheetprotection.md
+++ b/reference/excel/worksheetprotection.md
@@ -4,69 +4,120 @@ Represents the protection of a sheet object.
 
 ## Properties
 
-| Property	   | Type	|Description| Req. Set|
-|:---------------|:--------|:----------|:----|
-|protected|bool|Indicates if the worksheet is protected. Read-Only. Read-only.|[1.2](../requirement-sets/excel-api-requirement-sets.md)|
+| Property  | Type | Description                                                    | Req. Set                                                 |
+| :-------- | :--- | :------------------------------------------------------------- | :------------------------------------------------------- |
+| protected | bool | Indicates if the worksheet is protected. Read-Only. Read-only. | [1.2](../requirement-sets/excel-api-requirement-sets.md) |
 
 ## Relationships
-| Relationship | Type	|Description| Req. Set|
-|:---------------|:--------|:----------|:----|
-|options|[WorksheetProtectionOptions](worksheetprotectionoptions.md)|Sheet protection options. Read-Only. Read-only.|[1.2](../requirement-sets/excel-api-requirement-sets.md)|
+
+| Relationship | Type                           | Description                                     | Req. Set                                                 |
+| :----------- | :----------------------------- | :---------------------------------------------- | :------------------------------------------------------- |
+| options      | [WorksheetProtectionOptions][] | Sheet protection options. Read-Only. Read-only. | [1.2](../requirement-sets/excel-api-requirement-sets.md) |
 
 ## Methods
 
-| Method		   | Return Type	|Description| Req. Set|
-|:---------------|:--------|:----------|:----|
-|[protect(options: WorksheetProtectionOptions, password: string)](#protectoptions-worksheetprotectionoptions-password-string)|void|Protects a worksheet. Fails if the worksheet has already been protected.|[1.2](../requirement-sets/excel-api-requirement-sets.md)|
-|[unprotect(password: string)](#unprotectpassword-string)|void|Unprotects a worksheet.|[1.2](../requirement-sets/excel-api-requirement-sets.md)|
+| Method                                                                                                                       | Return Type | Description                                                              | Req. Set                                                 |
+| :--------------------------------------------------------------------------------------------------------------------------- | :---------- | :----------------------------------------------------------------------- | :------------------------------------------------------- |
+| [protect(options: WorksheetProtectionOptions, password: string)](#protectoptions-worksheetprotectionoptions-password-string) | void        | Protects a worksheet. Fails if the worksheet has already been protected. | [1.2](../requirement-sets/excel-api-requirement-sets.md) |
+| [unprotect(password: string)](#unprotectpassword-string)                                                                     | void        | Unprotects a worksheet.                                                  | [1.2](../requirement-sets/excel-api-requirement-sets.md) |
 
 ## Method Details
 
-
 ### protect(options: WorksheetProtectionOptions, password: string)
+
 Protects a worksheet. Fails if the worksheet has already been protected.
 
 #### Syntax
+
 ```js
 worksheetProtectionObject.protect(options, password);
 ```
 
 #### Parameters
-| Parameter	   | Type	|Description|
-|:---------------|:--------|:----------|
-|options|WorksheetProtectionOptions|Optional. sheet protection options.|
-|password|string|Optional. sheet protection password.|
+
+| Parameter | Type                       | Description                          |
+| :-------- | :------------------------- | :----------------------------------- |
+| options   | WorksheetProtectionOptions | Optional. sheet protection options.  |
+| password  | string                     | Optional. sheet protection password. |
 
 #### Returns
+
 void
 
 #### Examples
-```js
-Excel.run(function (ctx) { 
-	var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-	var range = sheet.getRange("A1:B3").format.protection.locked = false;
-	sheet.protection.protect({allowInsertRows:true});
-	return ctx.sync(); 
-}).catch(function(error) {
-		console.log("Error: " + error);
-		if (error instanceof OfficeExtension.Error) {
-			console.log("Debug info: " + JSON.stringify(error.debugInfo));
-		}
-});
 
+```js
+Excel.run(function(ctx) {
+  // get a reference to Sheet1
+  var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+
+  // Protect inserting or deleting rows in Sheet1
+  sheet.protection.protect({
+    allowInsertRows: false,
+    allowDeleteRows: false
+  });
+
+  return ctx.sync();
+}).catch(function(error) {
+  console.log("Error: " + error);
+  if (error instanceof OfficeExtension.Error) {
+    console.log("Debug info: " + JSON.stringify(error.debugInfo));
+  }
+});
 ```
+
 ### unprotect(password: string)
+
 Unprotects a worksheet.
 
 #### Syntax
+
 ```js
 worksheetProtectionObject.unprotect(password);
 ```
 
 #### Parameters
-| Parameter	   | Type	|Description|
-|:---------------|:--------|:----------|
-|password|string|Optional. sheet protection password.|
+
+| Parameter | Type   | Description                          |
+| :-------- | :----- | :----------------------------------- |
+| password  | string | Optional. sheet protection password. |
 
 #### Returns
+
 void
+
+#### Examples
+
+```js
+Excel.run(function(ctx) {
+  // get a reference to Sheet1
+  var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+
+  // Remove all protects applied to Sheet1
+  sheet.protection.unprotect();
+
+  return ctx.sync();
+}).catch(function(error) {
+  console.log("Error: " + error);
+  if (error instanceof OfficeExtension.Error) {
+    console.log("Debug info: " + JSON.stringify(error.debugInfo));
+  }
+});
+```
+
+#### Remakes
+
+Unprotecting a worksheet with `unprotect()` will remove _all_ [WorksheetProtectionOptions][] options applied to a worksheet.
+To remove only a subset of WorksheetProtectionOptions use the `protect()` method and set the options you wish to remove to `true`.
+
+```js
+Excel.run(function(ctx) {
+  var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+  sheet.protection.protect({
+    allowInsertRows: false, // Protect row insertion
+    allowDeleteRows: true // Unprotect row deletion
+  });
+});
+```
+
+[worksheetprotectionoptions]: worksheetprotectionoptions.md

--- a/reference/excel/worksheetprotectionoptions.md
+++ b/reference/excel/worksheetprotectionoptions.md
@@ -4,29 +4,33 @@ Represents the options in sheet protection.
 
 ## Properties
 
-| Property	   | Type	|Description| Req. Set|
-|:---------------|:--------|:----------|:----|
-|allowAutoFilter|bool|Represents the worksheet protection option of allowing using auto filter feature.|[1.2](../requirement-sets/excel-api-requirement-sets.md)|
-|allowDeleteColumns|bool|Represents the worksheet protection option of allowing deleting columns.|[1.2](../requirement-sets/excel-api-requirement-sets.md)|
-|allowDeleteRows|bool|Represents the worksheet protection option of allowing deleting rows.|[1.2](../requirement-sets/excel-api-requirement-sets.md)|
-|allowEditObjects|bool|Represents the worksheet protection option of allowing editing objects.|[1.7](../requirement-sets/excel-api-requirement-sets.md)|
-|allowEditScenarios|bool|Represents the worksheet protection option of allowing editing scenarios.|[1.7](../requirement-sets/excel-api-requirement-sets.md)|
-|allowFormatCells|bool|Represents the worksheet protection option of allowing formatting cells.|[1.2](../requirement-sets/excel-api-requirement-sets.md)|
-|allowFormatColumns|bool|Represents the worksheet protection option of allowing formatting columns.|[1.2](../requirement-sets/excel-api-requirement-sets.md)|
-|allowFormatRows|bool|Represents the worksheet protection option of allowing formatting rows.|[1.2](../requirement-sets/excel-api-requirement-sets.md)|
-|allowInsertColumns|bool|Represents the worksheet protection option of allowing inserting columns.|[1.2](../requirement-sets/excel-api-requirement-sets.md)|
-|allowInsertHyperlinks|bool|Represents the worksheet protection option of allowing inserting hyperlinks.|[1.2](../requirement-sets/excel-api-requirement-sets.md)|
-|allowInsertRows|bool|Represents the worksheet protection option of allowing inserting rows.|[1.2](../requirement-sets/excel-api-requirement-sets.md)|
-|allowPivotTables|bool|Represents the worksheet protection option of allowing using PivotTable feature.|[1.2](../requirement-sets/excel-api-requirement-sets.md)|
-|allowSort|bool|Represents the worksheet protection option of allowing using sort feature.|[1.2](../requirement-sets/excel-api-requirement-sets.md)|
+| Property              | Type | Description                                                                       | Req. Set |
+| :-------------------- | :--- | :-------------------------------------------------------------------------------- | :------- |
+| allowAutoFilter       | bool | Represents the worksheet protection option of allowing using auto filter feature. | [1.2]    |
+| allowDeleteColumns    | bool | Represents the worksheet protection option of allowing deleting columns.          | [1.2]    |
+| allowDeleteRows       | bool | Represents the worksheet protection option of allowing deleting rows.             | [1.2]    |
+| allowEditObjects      | bool | Represents the worksheet protection option of allowing editing objects.           | [1.7]    |
+| allowEditScenarios    | bool | Represents the worksheet protection option of allowing editing scenarios.         | [1.7]    |
+| allowFormatCells      | bool | Represents the worksheet protection option of allowing formatting cells.          | [1.2]    |
+| allowFormatColumns    | bool | Represents the worksheet protection option of allowing formatting columns.        | [1.2]    |
+| allowFormatRows       | bool | Represents the worksheet protection option of allowing formatting rows.           | [1.2]    |
+| allowInsertColumns    | bool | Represents the worksheet protection option of allowing inserting columns.         | [1.2]    |
+| allowInsertHyperlinks | bool | Represents the worksheet protection option of allowing inserting hyperlinks.      | [1.2]    |
+| allowInsertRows       | bool | Represents the worksheet protection option of allowing inserting rows.            | [1.2]    |
+| allowPivotTables      | bool | Represents the worksheet protection option of allowing using PivotTable feature.  | [1.2]    |
+| allowSort             | bool | Represents the worksheet protection option of allowing using sort feature.        | [1.2]    |
 
 _See property access [examples.](#property-access-examples)_
 
 ## Relationships
-| Relationship | Type	|Description| Req. Set|
-|:---------------|:--------|:----------|:----|
-|selectionMode|[ProtectionSelectionMode](protectionselectionmode.md)|Represents the worksheet protection option of selection mode. Possible values: Normal, Unlocked. None|[1.7](../requirement-sets/excel-api-requirement-sets.md)|
+
+| Relationship  | Type                                                  | Description                                                                                           | Req. Set |
+| :------------ | :---------------------------------------------------- | :---------------------------------------------------------------------------------------------------- | :------- |
+| selectionMode | [ProtectionSelectionMode](protectionselectionmode.md) | Represents the worksheet protection option of selection mode. Possible values: Normal, Unlocked. None | [1.7]    |
 
 ## Methods
+
 None
 
+[1.2]: ../requirement-sets/excel-api-requirement-sets.md
+[1.7]: ../requirement-sets/excel-api-requirement-sets.md


### PR DESCRIPTION
The example provided for `protect()` was incorrect and actually did the oposite (it removed protection).

I've also added a sample for `unprotect` and remarks on how to remove a subset of protections.

Fixes issue raised on Stack Overflow: https://stackoverflow.com/questions/49572230/password-is-not-getting-applied-when-i-protect-sheet