### PR TITLE
add note on blocked attachments

### DIFF
--- a/reference/outlook/1.1/Office.context.mailbox.item.md
+++ b/reference/outlook/1.1/Office.context.mailbox.item.md
@@ -38,6 +38,8 @@ Office.initialize = function () {
 
 Gets an array of attachments for the item. Read mode only.
 
+> **Note:** Certain attachments are blocked by Outlook due to potential security issues. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
+
 ##### Type:
 
 *   Array.<[AttachmentDetails](simple-types.md#attachmentdetails)>

--- a/reference/outlook/1.1/Office.context.mailbox.item.md
+++ b/reference/outlook/1.1/Office.context.mailbox.item.md
@@ -38,7 +38,7 @@ Office.initialize = function () {
 
 Gets an array of attachments for the item. Read mode only.
 
-> **Note:** Certain attachments are blocked by Outlook due to potential security issues. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
+> **Note:** Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
 
 ##### Type:
 

--- a/reference/outlook/1.2/Office.context.mailbox.item.md
+++ b/reference/outlook/1.2/Office.context.mailbox.item.md
@@ -38,6 +38,8 @@ Office.initialize = function () {
 
 Gets an array of attachments for the item. Read mode only.
 
+> **Note:** Certain attachments are blocked by Outlook due to potential security issues. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
+
 ##### Type:
 
 *   Array.<[AttachmentDetails](simple-types.md#attachmentdetails)>

--- a/reference/outlook/1.2/Office.context.mailbox.item.md
+++ b/reference/outlook/1.2/Office.context.mailbox.item.md
@@ -38,7 +38,7 @@ Office.initialize = function () {
 
 Gets an array of attachments for the item. Read mode only.
 
-> **Note:** Certain attachments are blocked by Outlook due to potential security issues. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
+> **Note:** Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
 
 ##### Type:
 

--- a/reference/outlook/1.3/Office.context.mailbox.item.md
+++ b/reference/outlook/1.3/Office.context.mailbox.item.md
@@ -38,6 +38,8 @@ Office.initialize = function () {
 
 Gets an array of attachments for the item. Read mode only.
 
+> **Note:** Certain attachments are blocked by Outlook due to potential security issues. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
+
 ##### Type:
 
 *   Array.<[AttachmentDetails](simple-types.md#attachmentdetails)>

--- a/reference/outlook/1.3/Office.context.mailbox.item.md
+++ b/reference/outlook/1.3/Office.context.mailbox.item.md
@@ -38,7 +38,7 @@ Office.initialize = function () {
 
 Gets an array of attachments for the item. Read mode only.
 
-> **Note:** Certain attachments are blocked by Outlook due to potential security issues. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
+> **Note:** Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
 
 ##### Type:
 

--- a/reference/outlook/1.4/Office.context.mailbox.item.md
+++ b/reference/outlook/1.4/Office.context.mailbox.item.md
@@ -38,6 +38,8 @@ Office.initialize = function () {
 
 Gets an array of attachments for the item. Read mode only.
 
+> **Note:** Certain attachments are blocked by Outlook due to potential security issues. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
+
 ##### Type:
 
 *   Array.<[AttachmentDetails](simple-types.md#attachmentdetails)>

--- a/reference/outlook/1.4/Office.context.mailbox.item.md
+++ b/reference/outlook/1.4/Office.context.mailbox.item.md
@@ -38,7 +38,7 @@ Office.initialize = function () {
 
 Gets an array of attachments for the item. Read mode only.
 
-> **Note:** Certain attachments are blocked by Outlook due to potential security issues. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
+> **Note:** Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
 
 ##### Type:
 

--- a/reference/outlook/1.5/Office.context.mailbox.item.md
+++ b/reference/outlook/1.5/Office.context.mailbox.item.md
@@ -79,7 +79,7 @@ Office.initialize = function () {
 
 Gets an array of attachments for the item. Read mode only.
 
-> **Note:** Certain attachments are blocked by Outlook due to potential security issues. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
+> **Note:** Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
 
 ##### Type:
 

--- a/reference/outlook/1.5/Office.context.mailbox.item.md
+++ b/reference/outlook/1.5/Office.context.mailbox.item.md
@@ -79,6 +79,8 @@ Office.initialize = function () {
 
 Gets an array of attachments for the item. Read mode only.
 
+> **Note:** Certain attachments are blocked by Outlook due to potential security issues. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
+
 ##### Type:
 
 *   Array.<[AttachmentDetails](simple-types.md#attachmentdetails)>

--- a/reference/outlook/1.6/Office.context.mailbox.item.md
+++ b/reference/outlook/1.6/Office.context.mailbox.item.md
@@ -38,6 +38,8 @@ Office.initialize = function () {
 
 Gets an array of attachments for the item. Read mode only.
 
+> **Note:** Certain attachments are blocked by Outlook due to potential security issues. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
+
 ##### Type:
 
 *   Array.<[AttachmentDetails](simple-types.md#attachmentdetails)>

--- a/reference/outlook/1.6/Office.context.mailbox.item.md
+++ b/reference/outlook/1.6/Office.context.mailbox.item.md
@@ -38,7 +38,7 @@ Office.initialize = function () {
 
 Gets an array of attachments for the item. Read mode only.
 
-> **Note:** Certain attachments are blocked by Outlook due to potential security issues. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
+> **Note:** Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
 
 ##### Type:
 

--- a/reference/outlook/preview/Office.context.mailbox.item.md
+++ b/reference/outlook/preview/Office.context.mailbox.item.md
@@ -38,6 +38,8 @@ Office.initialize = function () {
 
 Gets an array of attachments for the item. Read mode only.
 
+> **Note:** Certain attachments are blocked by Outlook due to potential security issues. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
+
 ##### Type:
 
 *   Array.<[AttachmentDetails](simple-types.md#attachmentdetails)>

--- a/reference/outlook/preview/Office.context.mailbox.item.md
+++ b/reference/outlook/preview/Office.context.mailbox.item.md
@@ -38,7 +38,7 @@ Office.initialize = function () {
 
 Gets an array of attachments for the item. Read mode only.
 
-> **Note:** Certain attachments are blocked by Outlook due to potential security issues. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
+> **Note:** Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see [Blocked attachments in Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519).
 
 ##### Type:
 


### PR DESCRIPTION
Outcome from Stack Overflow post (https://stackoverflow.com/questions/49860461/missing-attachment-from-outlook-js-api) and addresses resulting issue: https://github.com/OfficeDev/office-js/issues/94